### PR TITLE
fix(markdown): restore refresh switcher localization

### DIFF
--- a/Monica.Markdown/Localization/MarkdownResource/en-US.json
+++ b/Monica.Markdown/Localization/MarkdownResource/en-US.json
@@ -11,6 +11,9 @@
     "Documentation": "Documentation"
   },
   "MarkdownViewer": {
+    "Actions": {
+      "Refresh": "Refresh"
+    },
     "Placeholders": {
       "SearchFiles": "Search files",
       "SearchKnowledgeBases": "Find a knowledge base..."
@@ -18,6 +21,7 @@
     "States": {
       "LoadingDocuments": "Loading documents...",
       "LoadingDocument": "Loading document...",
+      "RefreshingKnowledgeBases": "Refreshing knowledge bases...",
       "NoKnowledgeBasesRegistered": "No knowledge bases registered",
       "NoKnowledgeBases": "No knowledge bases available",
       "NoMatchingKnowledgeBases": "No matching knowledge bases",

--- a/Monica.Markdown/Localization/MarkdownResource/zh-CN.json
+++ b/Monica.Markdown/Localization/MarkdownResource/zh-CN.json
@@ -11,6 +11,9 @@
     "Documentation": "文档"
   },
   "MarkdownViewer": {
+    "Actions": {
+      "Refresh": "刷新"
+    },
     "Placeholders": {
       "SearchFiles": "搜索文件",
       "SearchKnowledgeBases": "查找知识库..."
@@ -18,6 +21,7 @@
     "States": {
       "LoadingDocuments": "正在加载文档...",
       "LoadingDocument": "正在加载文档内容...",
+      "RefreshingKnowledgeBases": "正在刷新知识库...",
       "NoKnowledgeBasesRegistered": "未注册任何知识库。",
       "NoKnowledgeBases": "没有可用的知识库。",
       "NoMatchingKnowledgeBases": "没有匹配的知识库。",

--- a/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
+++ b/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
@@ -1,23 +1,46 @@
 @using Microsoft.Extensions.Localization
 @using Monica.Markdown.Localization
 @using Monica.Markdown.Models
+@using Monica.Markdown.UIMarkdown.Services
+@using Monica.Tool.MoResponse
 @inject IStringLocalizer<MarkdownResource> L
+@inject MarkdownUIService MarkdownService
 
 <MudDialog>
     <DialogContent>
         <div class="group-switcher-dialog">
-            <MudTextField T="string"
-                          @bind-Value="_searchText"
-                          Placeholder="@L["MarkdownViewer:Placeholders:SearchKnowledgeBases"]"
-                          Adornment="Adornment.Start"
-                          AdornmentIcon="@Icons.Material.Filled.Search"
-                          Variant="Variant.Outlined"
-                          Margin="Margin.Dense"
-                          Immediate="true"
-                          Class="group-switcher-search" />
+            <div class="group-switcher-search-row">
+                <MudTextField T="string"
+                              @bind-Value="_searchText"
+                              Placeholder="@L["MarkdownViewer:Placeholders:SearchKnowledgeBases"]"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Immediate="true"
+                              Class="group-switcher-search" />
+
+                <MudTooltip Text="@L["MarkdownViewer:Actions:Refresh"]">
+                    <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                                   Color="Color.Primary"
+                                   Size="Size.Medium"
+                                   Disabled="_refreshing"
+                                   OnClick="RefreshGroupsAsync"
+                                   Class="group-switcher-refresh" />
+                </MudTooltip>
+            </div>
 
             <div class="group-switcher-list">
-                @if (FilteredGroups.Count == 0)
+                @if (_refreshing)
+                {
+                    <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="group-switcher-empty">
+                        <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+                        <MudText Typo="Typo.body2" Color="Color.Default" Style="opacity: 0.65;">
+                            @L["MarkdownViewer:Messages:RefreshingDocuments"]
+                        </MudText>
+                    </MudStack>
+                }
+                else if (FilteredGroups.Count == 0)
                 {
                     <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="group-switcher-empty">
                         <MudIcon Icon="@Icons.Material.Filled.SearchOff"
@@ -51,6 +74,7 @@
     public string? SelectedGroupKey { get; set; }
 
     private string? _searchText;
+    private bool _refreshing;
 
     private List<MarkdownDocumentGroup> FilteredGroups =>
         Groups.Where(MatchesSearch).ToList();
@@ -59,6 +83,36 @@
     {
         MudDialog.Close(DialogResult.Ok(groupKey));
         return Task.CompletedTask;
+    }
+
+    private async Task RefreshGroupsAsync()
+    {
+        if (_refreshing)
+        {
+            return;
+        }
+
+        _refreshing = true;
+        try
+        {
+            var refreshResult = await MarkdownService.RefreshAllAsync();
+            if (refreshResult.IsFailed(out _))
+            {
+                return;
+            }
+
+            if ((await MarkdownService.GetAllDocumentGroupsAsync()).IsFailed(out _, out var groups))
+            {
+                return;
+            }
+
+            Groups = groups;
+            StateHasChanged();
+        }
+        finally
+        {
+            _refreshing = false;
+        }
     }
 
     private bool MatchesSearch(MarkdownDocumentGroup group)

--- a/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
+++ b/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
@@ -37,7 +37,7 @@
                     <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="group-switcher-empty">
                         <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
                         <MudText Typo="Typo.body2" Color="Color.Default" Style="opacity: 0.65;">
-                            @L["MarkdownViewer:Messages:RefreshingDocuments"]
+                            @L["MarkdownViewer:States:RefreshingKnowledgeBases"]
                         </MudText>
                     </MudStack>
                 }

--- a/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
+++ b/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
@@ -111,7 +111,6 @@
             }
 
             Groups = groups;
-            StateHasChanged();
         }
         finally
         {

--- a/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
+++ b/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor
@@ -5,6 +5,7 @@
 @using Monica.Tool.MoResponse
 @inject IStringLocalizer<MarkdownResource> L
 @inject MarkdownUIService MarkdownService
+@inject ISnackbar Snackbar
 
 <MudDialog>
     <DialogContent>
@@ -96,13 +97,16 @@
         try
         {
             var refreshResult = await MarkdownService.RefreshAllAsync();
-            if (refreshResult.IsFailed(out _))
+            if (refreshResult.IsFailed(out var refreshError))
             {
+                Snackbar.Add(refreshError, Severity.Error);
                 return;
             }
 
-            if ((await MarkdownService.GetAllDocumentGroupsAsync()).IsFailed(out _, out var groups))
+            var groupsResult = await MarkdownService.GetAllDocumentGroupsAsync();
+            if (groupsResult.IsFailed(out var groupsError, out var groups))
             {
+                Snackbar.Add(groupsError, Severity.Error);
                 return;
             }
 

--- a/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor.css
+++ b/Monica.Markdown/UIMarkdown/Components/DocumentGroupSwitcherDialog.razor.css
@@ -4,8 +4,19 @@
     gap: 12px;
 }
 
+.group-switcher-search-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 ::deep .group-switcher-search {
     width: 100%;
+    flex: 1;
+}
+
+.group-switcher-refresh {
+    flex: 0 0 auto;
 }
 
 .group-switcher-list {


### PR DESCRIPTION
## Summary
- replay the markdown group switcher refresh changes on a fresh branch from `dev`
- add the missing `MarkdownViewer` localization keys for the refresh UI
- move the in-progress text to a proper markdown viewer state key

## Validation
- `python3 .codex/skills/mo-ui-development/scripts/validate_localization.py`
- `git diff --check`
- `dotnet build` unavailable in this container (`dotnet` is not installed)