### PR TITLE
docs: continue translation quality review across modules

### DIFF
--- a/Monica.AutoModel/Annotations/AutoFieldAttribute.cs
+++ b/Monica.AutoModel/Annotations/AutoFieldAttribute.cs
@@ -17,7 +17,7 @@ public class AutoFieldAttribute : Attribute
     /// <summary>
     /// Whether to use the field title as an activation name. If <c>null</c>, the parent setting is used.
     /// </summary>
-    [Obsolete("暂未实现")]
+    [Obsolete("Not implemented yet.")]
     public bool? TitleAsActivateName { get; set; }
 
     /// <summary>
@@ -28,7 +28,7 @@ public class AutoFieldAttribute : Attribute
     /// <summary>
     /// Whether this field is required in filter expressions.
     /// </summary>
-    [Obsolete("暂未实现")]
+    [Obsolete("Not implemented yet.")]
     public bool IsRequired { get; set; }
 
     /// <summary>

--- a/Monica.AutoModel/Annotations/AutoTableAttribute.cs
+++ b/Monica.AutoModel/Annotations/AutoTableAttribute.cs
@@ -5,8 +5,9 @@ namespace Monica.AutoModel.Annotations;
 public class AutoTableAttribute : Attribute
 {
     /// <summary>
-    /// Active mode setting. When <c>false</c>, passive mode is used by default.
-    /// When <c>null</c>, the global module setting is used.
+    /// Controls whether the table uses active mode.
+    /// When <c>false</c>, passive mode is used by default.
+    /// When <c>null</c>, the module-level setting is used.
     /// </summary>
     public bool? ActiveMode { get; set; }
     /// <summary>

--- a/Monica.AutoModel/AutoModelExpressionGenerator.cs
+++ b/Monica.AutoModel/AutoModelExpressionGenerator.cs
@@ -5,16 +5,16 @@ using Monica.Tool.Extensions;
 namespace Monica.AutoModel;
 
 /// <summary>
-/// Expression tree generator for AutoModel.
+/// Builds Dynamic LINQ helper expressions for AutoModel.
 /// </summary>
 internal class AutoModelExpressionGenerator
 {
 
     /// <summary>
-    /// Generates an order-by expression string.
+    /// Generates a Dynamic LINQ order-by clause.
     /// </summary>
-    /// <param name="descend">Descending fields and their sort priorities.</param>
-    /// <param name="ascend">Ascending fields and their sort priorities.</param>
+    /// <param name="descend">Descending fields mapped to their sort priorities.</param>
+    /// <param name="ascend">Ascending fields mapped to their sort priorities.</param>
     /// <returns>The combined order expression, or <c>null</c> when no sorting is specified.</returns>
     public static string? GenerateOrderConditionString(Dictionary<string, int>? descend, Dictionary<string, int>? ascend)
     {
@@ -42,8 +42,8 @@ internal class AutoModelExpressionGenerator
     /// Generates a predicate delegate for delete, query, and existence-check operations.
     /// </summary>
     /// <param name="modelType">The target model type.</param>
-    /// <param name="fieldCondition">The string-based condition expression.</param>
-    /// <param name="fieldValues">The values referenced by the condition expression.</param>
+    /// <param name="fieldCondition">The filter condition expression.</param>
+    /// <param name="fieldValues">Parameter values referenced by the condition expression.</param>
     /// <returns>The generated predicate delegate, or <c>null</c> if the generic method cannot be resolved.</returns>
     public static object? GeneratePredicate(Type modelType, string fieldCondition, object?[]? fieldValues)
     {
@@ -52,11 +52,11 @@ internal class AutoModelExpressionGenerator
     }
 
     /// <summary>
-    /// Generates a predicate delegate from a condition expression.
+    /// Compiles a predicate delegate from a filter condition expression.
     /// </summary>
     /// <typeparam name="T">The model type.</typeparam>
-    /// <param name="fieldExpressions">The string-based condition expression.</param>
-    /// <param name="fieldValues">The values referenced by the condition expression.</param>
+    /// <param name="fieldExpressions">The filter condition expression.</param>
+    /// <param name="fieldValues">Parameter values referenced by the condition expression.</param>
     /// <returns>A compiled predicate delegate.</returns>
     public static Func<T, bool> GeneratePredicateGeneric<T>(string fieldExpressions, object[] fieldValues)
     {
@@ -65,10 +65,10 @@ internal class AutoModelExpressionGenerator
     }
 
     /// <summary>
-    /// Generates an assignment delegate for insert and update operations.
+    /// Generates a property-assignment delegate for insert and update operations.
     /// </summary>
     /// <param name="modelType">The target model type.</param>
-    /// <param name="fieldKeyValuePairs">The field-value pairs to assign.</param>
+    /// <param name="fieldKeyValuePairs">The property values to assign.</param>
     /// <returns>The generated assignment delegate, or <c>null</c> if the generic method cannot be resolved.</returns>
     public static object? GenerateAction(Type modelType, IEnumerable<KeyValuePair<string, object>> fieldKeyValuePairs)
     {
@@ -76,10 +76,10 @@ internal class AutoModelExpressionGenerator
             .MakeGenericMethod(modelType).Invoke(null, new object[] { fieldKeyValuePairs });
     }
     /// <summary>
-    /// Generates an assignment delegate for insert and update operations.
+    /// Generates a property-assignment delegate for insert and update operations.
     /// </summary>
     /// <typeparam name="T">The model type.</typeparam>
-    /// <param name="fieldKeyValuePairs">The field-value pairs to assign.</param>
+    /// <param name="fieldKeyValuePairs">The property values to assign.</param>
     /// <returns>A compiled assignment delegate.</returns>
     public static Action<T>? GenerateActionGeneric<T>(IEnumerable<KeyValuePair<string, object>> fieldKeyValuePairs) where T : new()
     {

--- a/Monica.AutoModel/Configurations/AutoFieldTypeSetting.cs
+++ b/Monica.AutoModel/Configurations/AutoFieldTypeSetting.cs
@@ -8,21 +8,21 @@ namespace Monica.AutoModel.Configurations;
 public class AutoFieldTypeSetting
 {
     /// <summary>
-    /// Declaring type that defines this field.
+    /// Type that declares this field.
     /// </summary>
     [JsonIgnore] public Type? DeclaringType { get; set; }
     /// <summary>
-    /// Original parameter type.
+    /// Original field type.
     /// </summary>
     [JsonIgnore] public Type OriginType { get; set; } = null!;
 
     /// <summary>
-    /// Underlying type of the original parameter after unwrapping nullable and <see cref="IEnumerable"/> wrappers.
+    /// Underlying field type after unwrapping nullable and <see cref="IEnumerable"/> wrappers.
     /// </summary>
     [JsonIgnore] public Type OriginUnderlyingType { get; set; } = null!;
 
     /// <summary>
-    /// Type features.
+    /// Detected type features.
     /// </summary>
     public ETypeFeatures TypeFeatures { get; set; }
 
@@ -33,7 +33,7 @@ public class AutoFieldTypeSetting
     public EBasicType BasicType { get; set; }
 
     /// <summary>
-    /// Underlying type name.
+    /// Name of the underlying field type.
     /// </summary>
     public string TypeName => OriginUnderlyingType.Name;
 
@@ -44,9 +44,9 @@ public class AutoFieldTypeSetting
     }
 
     /// <summary>
-    /// Automatically populates the type settings from the parameter type.
+    /// Populates the type metadata from the supplied field type.
     /// </summary>
-    /// <param name="parameterType">The parameter type to analyze.</param>
+    /// <param name="parameterType">The field type to analyze.</param>
     private void AutoSetTypeSetting(Type parameterType)
     {
         OriginType = parameterType;
@@ -158,7 +158,7 @@ public class AutoFieldTypeSetting
 
 
         if (underlyingType == typeof(char)) return EBasicType.IsChar;
-        if (underlyingType.IsClass) return EBasicType.IsClass;//string is also class.
+        if (underlyingType.IsClass) return EBasicType.IsClass; // string is also a class.
         throw new AutoModelSnapshotNotSupportTypeException(
             displayMessage: "字段类型不支持",
             technicalDetail: $"不支持的类型: {underlyingType.GetCleanFullName()}",

--- a/Monica.AutoModel/Configurations/AutoModelFuzzSetting.cs
+++ b/Monica.AutoModel/Configurations/AutoModelFuzzSetting.cs
@@ -1,16 +1,16 @@
 namespace Monica.AutoModel.Configurations;
 
 /// <summary>
-/// Fuzzy-search settings for a field.
+/// Fuzzy-match settings for a field.
 /// </summary>
 public class AutoModelFuzzSetting
 {
     /// <summary>
-    /// Indicates that fuzzy search is currently unsupported for this field type.
+    /// Indicates that fuzzy matching is not supported for this field type.
     /// </summary>
     public bool IsNotSupported { get; set; }
     /// <summary>
-    /// Whether this field should be ignored during full-field fuzzy searches.
+    /// Indicates that this field is excluded from full-field fuzzy searches.
     /// </summary>
     public bool IsIgnored { get; set; }
 }

--- a/Monica.AutoModel/Exceptions/AutoModelInvokerException.cs
+++ b/Monica.AutoModel/Exceptions/AutoModelInvokerException.cs
@@ -1,7 +1,7 @@
 namespace Monica.AutoModel.Exceptions;
 
 /// <summary>
-/// Invocation execution error.
+/// Exception thrown when an AutoModel invocation fails.
 /// </summary>
 public class AutoModelInvokerException(string displayMessage, string? technicalDetail = null)
     : AutoModelBaseException(displayMessage, technicalDetail);

--- a/Monica.AutoModel/Exceptions/AutoModelNormalizeException.cs
+++ b/Monica.AutoModel/Exceptions/AutoModelNormalizeException.cs
@@ -1,13 +1,13 @@
 namespace Monica.AutoModel.Exceptions;
 
 /// <summary>
-/// Expression or query normalization/parsing error.
+/// Exception thrown when an expression or query cannot be normalized or parsed.
 /// </summary>
 public class AutoModelNormalizeException(string displayMessage, string? technicalDetail = null)
     : AutoModelBaseException(displayMessage, technicalDetail);
 
 /// <summary>
-/// Token expression generation error.
+/// Exception thrown when token expression generation fails.
 /// </summary>
 public class AutoModelTokenExpGenException(string displayMessage, string? technicalDetail = null)
     : AutoModelBaseException(displayMessage, technicalDetail);

--- a/Monica.AutoModel/Exceptions/AutoModelSnapshotException.cs
+++ b/Monica.AutoModel/Exceptions/AutoModelSnapshotException.cs
@@ -1,13 +1,13 @@
 namespace Monica.AutoModel.Exceptions;
 
 /// <summary>
-/// Snapshot construction or configuration error.
+/// Exception thrown when snapshot construction or configuration fails.
 /// </summary>
 public class AutoModelSnapshotException(string displayMessage, string? technicalDetail = null)
     : AutoModelBaseException(displayMessage, technicalDetail);
 
 /// <summary>
-/// Exception for unsupported types in a snapshot.
+/// Exception thrown when a snapshot encounters an unsupported field type.
 /// </summary>
 public class AutoModelSnapshotNotSupportTypeException(
     string displayMessage,
@@ -16,7 +16,7 @@ public class AutoModelSnapshotNotSupportTypeException(
     : AutoModelSnapshotException(displayMessage, technicalDetail)
 {
     /// <summary>
-    /// Unsupported field type related to the error.
+    /// Unsupported field type involved in the error.
     /// </summary>
     public Type FromPropertyType { get; } = fromPropertyType;
 }

--- a/Monica.AutoModel/Exceptions/AutoModelValueConvertException.cs
+++ b/Monica.AutoModel/Exceptions/AutoModelValueConvertException.cs
@@ -1,7 +1,7 @@
 namespace Monica.AutoModel.Exceptions;
 
 /// <summary>
-/// Value conversion error.
+/// Exception thrown when a field value cannot be converted.
 /// </summary>
 public class AutoModelValueConvertException(string displayMessage, string? technicalDetail = null)
     : AutoModelBaseException(displayMessage, technicalDetail);

--- a/Monica.AutoModel/Implements/AutoModelDbOperatorDynamicLinqProvider.cs
+++ b/Monica.AutoModel/Implements/AutoModelDbOperatorDynamicLinqProvider.cs
@@ -41,7 +41,7 @@ public class AutoModelDbOperatorDynamicLinqProvider<TModel>(IAutoModelExpression
     }
     public virtual IQueryable<TModel> ApplyFilter(IQueryable<TModel> queryable, string filter)
     {
-        // Test/backdoor hook for debugging.
+        // Debug escape hatch for raw Dynamic LINQ expressions.
         if (filter.StartsWith('[') && filter.EndsWith(']'))
         {
             return queryable.Where(_config, filter.TrimStart('[').TrimEnd(']'));

--- a/Monica.AutoModel/Implements/AutoModelExpressionNormalizerDynamicLinqProvider.cs
+++ b/Monica.AutoModel/Implements/AutoModelExpressionNormalizerDynamicLinqProvider.cs
@@ -63,7 +63,7 @@ public class AutoModelExpressionNormalizerDynamicLinqProvider<TModel>(
     }
 
     /// <summary>
-    /// Gets the select expression for a field.
+    /// Builds the Dynamic LINQ select expression for a field.
     /// </summary>
     /// <param name="field"></param>
     /// <returns></returns>

--- a/Monica.AutoModel/Implements/AutoModelExpressionNormalizerDynamicLinqProvider.cs
+++ b/Monica.AutoModel/Implements/AutoModelExpressionNormalizerDynamicLinqProvider.cs
@@ -65,8 +65,8 @@ public class AutoModelExpressionNormalizerDynamicLinqProvider<TModel>(
     /// <summary>
     /// Builds the Dynamic LINQ select expression for a field.
     /// </summary>
-    /// <param name="field"></param>
-    /// <returns></returns>
+    /// <param name="field">The field metadata to translate.</param>
+    /// <returns>The Dynamic LINQ member-access expression for the field.</returns>
     private string GetSelectExpression(AutoField field)
     {
         if (field.NavigationProperties is { } list)

--- a/Monica.AutoModel/Implements/AutoModelExpressionTokenizer.cs
+++ b/Monica.AutoModel/Implements/AutoModelExpressionTokenizer.cs
@@ -142,7 +142,7 @@ public partial class AutoModelExpressionTokenizer<TModel>(
 
     public NormalizedResult GenFinalExpression(TokenizerContext context)
     {
-        var supplementObjects = new List<object>(); // Supplemental object parameter values for dynamic LINQ assignments.
+        var supplementObjects = new List<object>(); // Additional parameter values injected into generated Dynamic LINQ expressions.
         foreach (var (index, token) in context.Tokens.WithIndex())
         {
             var fieldInfo = token.FieldInfo!;
@@ -167,9 +167,10 @@ public partial class AutoModelExpressionTokenizer<TModel>(
 
 
     /// <summary>
-    /// Gets the current enum type's allowed range (only when the type is an enum).
+    /// Returns the supported literal values for the specified enum type.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="type">The enum type to inspect.</param>
+    /// <returns>A comma-separated list of supported values.</returns>
     private static string GetEnumRange(Type type)
     {
         return Enum.GetValues(type).Cast<Enum>()
@@ -178,9 +179,9 @@ public partial class AutoModelExpressionTokenizer<TModel>(
     }
 
     /// <summary>
-    /// Regular expression for parsing expressions.
+    /// Regular expression used to tokenize filter expressions.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The compiled tokenizer regex.</returns>
     [GeneratedRegex("""
                     (?<Field>[^(\s]+) (?<Condition>[\S]+) "(?<Value>.*?)"
                     """, RegexOptions.Compiled)]

--- a/Monica.AutoModel/Implements/AutoModelSnapshotMemoryProvider.cs
+++ b/Monica.AutoModel/Implements/AutoModelSnapshotMemoryProvider.cs
@@ -17,9 +17,9 @@ using Monica.Tool.Extensions;
 namespace Monica.AutoModel.Implements;
 
 /// <summary>
-/// AutoModel in-memory snapshot service.
+/// Builds and caches in-memory AutoModel snapshots.
 /// </summary>
-/// <typeparam name="TModel"></typeparam>
+/// <typeparam name="TModel">The model type.</typeparam>
 public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel>
 {
     private static AutoModelSnapshot _snapshot = null!;
@@ -33,7 +33,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
 
     private static IEnumerable<PropertyInfo> GetAutoFieldTypes(Type type)
     {
-        // Caveat: string is also a reference type class. string? merely adds NullableContextAttribute, so treat string? the same as string using typeof(string).
+        // Note: string is also a reference type. string? only adds NullableContextAttribute, so treat string? the same as string by checking typeof(string).
         return type.GetProperties().OrderByDescending(p => p.PropertyType == typeof(string)).ThenBy(p => p.PropertyType.IsClass);
     }
 
@@ -58,7 +58,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
             isActiveMode = tableAttribute.ActiveMode ?? isActiveMode;
         }
 
-        var navigatedTypeNames = new HashSet<Type>();// Prevent nested navigation from causing stack overflows; only support one level deep for the same type.
+        var navigatedTypeNames = new HashSet<Type>(); // Prevent recursive navigation from causing stack overflows. Only one nested level is supported for the same type.
         List<string> allOriginActivateNames = [];
 
         ExtractFieldInfo(GetAutoFieldTypes(typeof(TModel)));
@@ -83,7 +83,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
                 // Skip when active mode is enabled but AutoFieldAttribute is missing.
                 if (isActiveMode && fieldAttribute == null) continue;
                 if (fieldAttribute?.Ignore is true) continue;
-                // Automatically ignore fields without AutoField attribute or annotated with NotMapped/JsonIgnore.
+                // Automatically ignore fields without AutoField when they are annotated with NotMapped or JsonIgnore.
                 if (fieldAttribute is null)
                 {
                     if (!options.DisableAutoIgnorePropertyWithNotMappedAttribute && p.GetCustomAttribute<NotMappedAttribute>() != null) continue;
@@ -94,7 +94,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
                 // Dictionary types are not supported.
                 if (typeof(IDictionary).IsAssignableFrom(p.PropertyType)) continue;
 
-                // Determine whether the property is a navigation property.
+                // Determine whether the property should be treated as a navigation property.
                 if (p.PropertyType.GetGenericUnderlyingType() is { IsClass: true } underlyingType && underlyingType != typeof(string))
                 {
                     if (!navigatedTypeNames.Add(underlyingType)) continue;
@@ -128,7 +128,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
                     }
 
 
-                    CheckFuzzSetting(p, field);
+                    CheckFuzzSetting(field);
 
                     if (fieldAttribute != null)
                     {
@@ -146,7 +146,7 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
                     if (activateNames.Count == 0)
                     {
                         var propertyName = field.DefaultActiveName;
-                        activateNames.Add(propertyName.ToLowerInvariant());// Normalized active name used for case-insensitive matching.
+                        activateNames.Add(propertyName.ToLowerInvariant()); // Normalized activation name used for case-insensitive matching.
                         allOriginActivateNames.Add(propertyName);
                     }
 
@@ -182,15 +182,14 @@ public class AutoModelSnapshotMemoryProvider<TModel> : IAutoModelSnapshot<TModel
     }
 
     /// <summary>
-    /// Validates fuzzy field configuration.
+    /// Validates fuzzy-match support for a field.
     /// </summary>
-    /// <param name="propertyInfo"></param>
-    /// <param name="fieldSetting"></param>
-    private static void CheckFuzzSetting(PropertyInfo propertyInfo, AutoField fieldSetting)
+    /// <param name="field">The field metadata to update.</param>
+    private static void CheckFuzzSetting(AutoField field)
     {
-        if (fieldSetting.TypeSetting.TypeFeatures.HasAnyFlag(ETypeFeatures.IsCollection, ETypeFeatures.IsClass))
+        if (field.TypeSetting.TypeFeatures.HasAnyFlag(ETypeFeatures.IsCollection, ETypeFeatures.IsClass))
         {
-            fieldSetting.FuzzSetting.IsNotSupported = true;
+            field.FuzzSetting.IsNotSupported = true;
         }
     }
 

--- a/Monica.AutoModel/Implements/AutoModelTokenExpressionGenDynamicLinqProvider.cs
+++ b/Monica.AutoModel/Implements/AutoModelTokenExpressionGenDynamicLinqProvider.cs
@@ -19,11 +19,11 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
     private FieldToken _token = null!;
     private object? _curValue = null!;
     /// <summary>
-    /// Represents the expression's value property.
+    /// Placeholder for the current value parameter in the generated expression.
     /// </summary>
     private string _curValueParam = null!;
     /// <summary>
-    /// Represents the current field property.
+    /// Field path used in the generated expression.
     /// </summary>
     private string _curFieldParam = null!;
     private int _curTotalParamCount = 0;
@@ -33,17 +33,17 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
     private bool _isMulti => (_features & EFieldConditionFeatures.Multi) != 0;
 
     /// <summary>
-    /// Dynamic extension methods for LinqToSql are not supported at runtime.
+    /// Function source used for generated <c>Like</c> expressions.
     /// </summary>
     protected virtual string LinqFunctions => (_features & EFieldConditionFeatures.UseClientSideEvaluations) != 0
         ? nameof(LinqToObjectFunctions)
         : "EF.Functions";
 
     /// <summary>
-    /// Determines whether the special ConvertedValue property requires ending generation early.
+    /// Handles special converted-value markers that short-circuit expression generation.
     /// </summary>
-    /// <param name="expression"></param>
-    /// <returns></returns>
+    /// <param name="expression">Receives the replacement expression when generation stops early.</param>
+    /// <returns><c>true</c> when generation should stop early; otherwise <c>false</c>.</returns>
     private bool ShouldBreakConvertedValue([NotNullWhen(true)] out string? expression)
     {
         expression = null;
@@ -76,7 +76,7 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
         {
             return $"{_curValueParam}.Contains({_curFieldParam})";
         }
-        //use https://eval-expression.net/linq-dynamic instead?
+        // Consider https://eval-expression.net/linq-dynamic instead.
 
         if (token.Conditions == EFieldConditions.Is)
         {
@@ -239,10 +239,10 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
     }
 
     /// <summary>
-    /// Adds supplemental parameters and returns the index where it was inserted.
+    /// Appends an auxiliary parameter and returns its parameter index.
     /// </summary>
-    /// <param name="supplement"></param>
-    /// <returns></returns>
+    /// <param name="supplement">The auxiliary parameter value.</param>
+    /// <returns>The absolute parameter index used in the generated expression.</returns>
     private int SupplementParameter(object supplement)
     {
         _supplementParameterObjects.Add(supplement);
@@ -275,9 +275,9 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
     #region Is
 
     /// <summary>
-    /// Parses an Is expression.
+    /// Generates the expression for an <c>is</c> condition.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The generated condition expression.</returns>
     private string ResolveIs()
     {
         if (_curValue is string exp && !string.IsNullOrWhiteSpace(exp))
@@ -309,9 +309,9 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
 
     #region ExpLike
     /// <summary>
-    /// Parses an ExpLike expression.
+    /// Generates the expression for an <c>explike</c> condition.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The generated condition expression.</returns>
     private string ResolveExpLike()
     {
         if (_curValue is string exp && !string.IsNullOrWhiteSpace(exp))
@@ -390,9 +390,9 @@ public partial class AutoModelTokenExpressionGenDynamicLinqProvider(IOptions<Aut
     }
 
     /// <summary>
-    /// ExpLike regular expression.
+    /// Regular expression used to split <c>explike</c> clauses.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The compiled <c>explike</c> splitter regex.</returns>
     [GeneratedRegex("""
                     [\|\(\)\&]
                     """, RegexOptions.Compiled)]

--- a/Monica.AutoModel/Implements/MoStringTool.cs
+++ b/Monica.AutoModel/Implements/MoStringTool.cs
@@ -103,11 +103,11 @@ public static partial class MoStringTool
     private static readonly string[] _supportedDateTimeFormats =
        ["yyyy-MM-dd", "yyyyMMdd", "MMdd", "yyyy-MM-dd HH:mm:ss", "yyMMdd"];
     /// <summary>
-    /// Converts value to DateTime.
+    /// Tries to parse a string into a <see cref="DateTime"/>.
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="dateTime"></param>
-    /// <returns></returns>
+    /// <param name="value">The raw input string.</param>
+    /// <param name="dateTime">The parsed <see cref="DateTime"/> value when parsing succeeds.</param>
+    /// <returns><c>true</c> when parsing succeeds; otherwise <c>false</c>.</returns>
     public static bool TryToDateTime(string value, out DateTime dateTime)
     {
         value = value.Trim();

--- a/Monica.AutoModel/Interfaces/IAutoModelDbOperator.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelDbOperator.cs
@@ -4,7 +4,7 @@ using Monica.AutoModel.Model;
 namespace Monica.AutoModel.Interfaces;
 
 /// <summary>
-/// AutoModel operations for database-backed queries.
+/// Provides AutoModel operations for database-backed queries.
 /// </summary>
 /// <typeparam name="TModel">The model type.</typeparam>
 public interface IAutoModelDbOperator<TModel> : IAutoModelOperator<TModel>
@@ -37,7 +37,7 @@ public interface IAutoModelDbOperator<TModel> : IAutoModelOperator<TModel>
     IQueryable<TModel> ApplyFilter(IQueryable<TModel> queryable, Expression<Func<TModel, object>> selector,
         EFieldConditions condition, string value);
     /// <summary>
-    /// Applies a fuzzy-search filter.
+    /// Applies a fuzzy-match filter.
     /// </summary>
     /// <param name="queryable">The source query.</param>
     /// <param name="fuzzy">The fuzzy-search value.</param>

--- a/Monica.AutoModel/Interfaces/IAutoModelExpressionNormalizer.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelExpressionNormalizer.cs
@@ -5,17 +5,17 @@ using Monica.Tool.General;
 namespace Monica.AutoModel.Interfaces;
 
 /// <summary>
-/// AutoModel expression normalizer.
+/// Normalizes AutoModel select, filter, and fuzzy expressions.
 /// </summary>
 /// <typeparam name="TModel">The model type.</typeparam>
 public interface IAutoModelExpressionNormalizer<TModel>
 {
     /// <summary>
-    /// Normalizes a selected-field expression.
+    /// Normalizes a field-selection expression.
     /// </summary>
-    /// <param name="selectColumns">The selected-field expression.</param>
+    /// <param name="selectColumns">The field-selection expression.</param>
     /// <param name="isReverseSelect">Whether this is a reverse selection that excludes the specified fields.</param>
-    /// <returns>The normalized expression.</returns>
+    /// <returns>The normalized Dynamic LINQ select expression.</returns>
     string NormalizeSelectColumns(string selectColumns, bool isReverseSelect = false);
 
     /// <summary>
@@ -26,7 +26,7 @@ public interface IAutoModelExpressionNormalizer<TModel>
     NormalizedResult NormalizeFilter(string filter);
 
     /// <summary>
-    /// Normalizes a fuzzy-search expression.
+    /// Normalizes a fuzzy-search request.
     /// </summary>
     /// <param name="fuzzy">The fuzzy-search value.</param>
     /// <param name="fuzzyColumns">Optional fields to include in fuzzy searching.</param>
@@ -34,24 +34,24 @@ public interface IAutoModelExpressionNormalizer<TModel>
     NormalizedResult NormalizeFuzzy(string fuzzy, string? fuzzyColumns = null);
 
     /// <summary>
-    /// Switches execution to LINQ to Objects.
+    /// Switches subsequent normalization to LINQ to Objects.
     /// </summary>
     void SetToLinqToObject();
 
     /// <summary>
-    /// Converts a selected-field expression into AutoModel field objects.
+    /// Resolves a field-selection expression to AutoModel fields.
     /// </summary>
-    /// <param name="columns">The selected-field expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
+    /// <param name="columns">The field-selection expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
     /// <param name="isReverseSelect">Whether this is a reverse selection that excludes the specified fields.</param>
-    /// <returns>The normalized AutoModel field objects.</returns>
+    /// <returns>The resolved AutoModel fields.</returns>
     List<AutoField> NormalizeLiteralSelect(string columns, bool isReverseSelect = false);
 
     /// <summary>
     /// <inheritdoc cref="NormalizeLiteralSelect"/>
     /// </summary>
-    /// <param name="selectExpression"></param>
-    /// <param name="isReverseSelect"></param>
-    /// <returns></returns>
+    /// <param name="selectExpression">The field-selection expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
+    /// <param name="isReverseSelect">Whether this is a reverse selection that excludes the specified fields.</param>
+    /// <returns>A tuple containing the resolved fields and the field names that could not be resolved.</returns>
     (List<AutoField> fields, List<string> failedList) NormalizeLiteralSelectWithoutException(string selectExpression,
         bool isReverseSelect = false);
 }

--- a/Monica.AutoModel/Interfaces/IAutoModelExpressionTokenizer.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelExpressionTokenizer.cs
@@ -5,10 +5,10 @@ namespace Monica.AutoModel.Interfaces;
 public interface IAutoModelExpressionTokenizer<TModel>
 {
     /// <summary>
-    /// Tokenize the expression
+    /// Tokenizes the supplied filter expression.
     /// </summary>
-    /// <param name="expression"></param>
-    /// <returns></returns>
+    /// <param name="expression">The raw filter expression.</param>
+    /// <returns>The tokenization context produced from the expression.</returns>
     TokenizerContext Tokenize(string expression)
     {
         var context = new TokenizerContext(expression);

--- a/Monica.AutoModel/Interfaces/IAutoModelMemoryOperator.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelMemoryOperator.cs
@@ -4,7 +4,7 @@ using Monica.AutoModel.Model;
 namespace Monica.AutoModel.Interfaces;
 
 /// <summary>
-/// AutoModel operations for in-memory queries.
+/// Provides AutoModel operations for in-memory queries.
 /// </summary>
 /// <typeparam name="TModel">The model type.</typeparam>
 public interface IAutoModelMemoryOperator<TModel> : IAutoModelOperator<TModel>
@@ -47,7 +47,7 @@ public interface IAutoModelMemoryOperator<TModel> : IAutoModelOperator<TModel>
     IEnumerable<TModel> ApplyFilter(IEnumerable<TModel> queryable, Expression<Func<TModel, object>> selector,
         EFieldConditions condition, string value);
     /// <summary>
-    /// Applies a fuzzy-search filter.
+    /// Applies a fuzzy-match filter.
     /// </summary>
     /// <param name="queryable">The source sequence.</param>
     /// <param name="fuzzy">The fuzzy-search value.</param>

--- a/Monica.AutoModel/Interfaces/IAutoModelOperator.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelOperator.cs
@@ -3,34 +3,37 @@ using Monica.AutoModel.Model;
 
 namespace Monica.AutoModel.Interfaces;
 
+/// <summary>
+/// Common AutoModel field-resolution and normalization operations.
+/// </summary>
 public interface IAutoModelOperator<TModel>
 {
     /// <summary>
-    /// Converts selected field names to AutoModel field objects.
+    /// Resolves the specified field activation names to AutoModel fields.
     /// </summary>
-    /// <param name="selectProperties">The selected field names.</param>
+    /// <param name="selectProperties">The field activation names to resolve.</param>
     /// <returns>The matching AutoModel field objects.</returns>
     List<AutoField> GetFields(params string[] selectProperties);
     /// <summary>
-    /// Converts selected field names to AutoModel field objects, excluding the specified fields.
+    /// Gets all AutoModel fields except the specified activation names.
     /// </summary>
-    /// <param name="selectProperties">The field names to exclude.</param>
+    /// <param name="selectProperties">The field activation names to exclude.</param>
     /// <returns>The remaining AutoModel field objects.</returns>
     List<AutoField> GetFieldsExpect(params string[] selectProperties);
 
     /// <summary>
-    /// Converts a selected-field expression into AutoModel field objects.
+    /// Resolves a field-selection expression to AutoModel fields.
     /// </summary>
-    /// <param name="selectExpression">The selected-field expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
+    /// <param name="selectExpression">The field-selection expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
     /// <param name="isReverseSelect">Whether this is a reverse selection that excludes the specified fields.</param>
-    /// <returns>The normalized AutoModel field objects.</returns>
+    /// <returns>The resolved AutoModel fields.</returns>
     List<AutoField> NormalizeLiteralSelect(string selectExpression, bool isReverseSelect = false);
     /// <summary>
     /// <inheritdoc cref="NormalizeLiteralSelect"/>
     /// </summary>
-    /// <param name="selectExpression"></param>
-    /// <param name="isReverseSelect"></param>
-    /// <returns></returns>
+    /// <param name="selectExpression">The field-selection expression separated by <see cref="AutoModelExpressionOptions.SelectSeparator"/>.</param>
+    /// <param name="isReverseSelect">Whether this is a reverse selection that excludes the specified fields.</param>
+    /// <returns>A tuple containing the resolved fields and the field names that could not be resolved.</returns>
     (List<AutoField> fields, List<string> failedList) NormalizeLiteralSelectWithoutException(string selectExpression,
         bool isReverseSelect = false);
 

--- a/Monica.AutoModel/Interfaces/IAutoModelSnapshot.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelSnapshot.cs
@@ -2,38 +2,41 @@ using Monica.AutoModel.Model;
 
 namespace Monica.AutoModel.Interfaces;
 
+/// <summary>
+/// Provides access to registered AutoModel snapshots.
+/// </summary>
 public interface IAutoModelSnapshotFactory
 {
     /// <summary>
-    /// Gets all generic AutoModel snapshots.
+    /// Gets all registered AutoModel snapshots.
     /// </summary>
     /// <returns>All registered snapshots.</returns>
     IReadOnlyList<AutoModelSnapshot> GetSnapshots();
 }
 
 /// <summary>
-/// Generic AutoModel snapshot interface.
+/// Represents a strongly typed AutoModel snapshot.
 /// </summary>
 /// <typeparam name="TModel">The model type.</typeparam>
 public interface IAutoModelSnapshot<TModel>
 {
     /// <summary>
-    /// Gets all activation names supported by the fields.
+    /// Gets all activation names exposed by the snapshot fields.
     /// </summary>
     /// <returns>All supported activation names.</returns>
     IReadOnlyList<string> GetAllActivateNames();
 
     /// <summary>
-    /// Gets field settings by the specified activation name.
+    /// Gets field metadata for the specified activation name.
     /// </summary>
     /// <param name="fieldActivateName">The activation name of the field.</param>
-    /// <returns>The matching field settings, or <c>null</c> if no match exists.</returns>
+    /// <returns>The matching field metadata, or <c>null</c> if no match exists.</returns>
     AutoField? GetField(string fieldActivateName);
 
     /// <summary>
-    /// Gets all field settings.
+    /// Gets field metadata.
     /// </summary>
     /// <param name="fieldActivateNames">Optional field activation names used to filter the result.</param>
-    /// <returns>The matching field settings.</returns>
+    /// <returns>The matching field metadata.</returns>
     IReadOnlyList<AutoField> GetFields(IReadOnlyList<string>? fieldActivateNames = null);
 }

--- a/Monica.AutoModel/Interfaces/IAutoModelTokenExpressionGen.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelTokenExpressionGen.cs
@@ -10,7 +10,7 @@ public interface IAutoModelTokenExpressionGen
     /// <param name="token">The field token.</param>
     /// <param name="num">The index of the field within the expression.</param>
     /// <param name="totalParamCount">The total number of existing parameters.</param>
-    /// <param name="supplementParamObjects">Additional parameter objects produced during generation.</param>
+    /// <param name="supplementParamObjects">Receives additional parameter objects produced during generation.</param>
     /// <remarks>https://dynamic-linq.net/expression-language#calling-method-and-constructor</remarks>
     /// <returns>The generated token expression.</returns>
     string GenerateTokenExpression(FieldToken token, int num, int totalParamCount,

--- a/Monica.AutoModel/Interfaces/IAutoModelTypeConverter.cs
+++ b/Monica.AutoModel/Interfaces/IAutoModelTypeConverter.cs
@@ -5,15 +5,15 @@ using Monica.AutoModel.Model;
 namespace Monica.AutoModel.Interfaces;
 
 /// <summary>
-/// AutoModel type converter.
+/// Converts raw filter values to typed AutoModel values.
 /// </summary>
 public interface IAutoModelTypeConverter
 {
     /// <summary>
-    /// Converts a field value.
+    /// Converts a raw field value.
     /// </summary>
     /// <param name="value">The raw string value.</param>
-    /// <param name="typeSetting">The field type settings.</param>
+    /// <param name="typeSetting">The target field type metadata.</param>
     /// <param name="features">Additional condition features that affect conversion.</param>
     /// <exception cref="AutoModelValueConvertException">Thrown when the value cannot be converted.</exception>
     /// <returns>The converted value.</returns>

--- a/Monica.AutoModel/Interfaces/IHasRequestFilter.cs
+++ b/Monica.AutoModel/Interfaces/IHasRequestFilter.cs
@@ -7,11 +7,11 @@ public interface IHasRequestFilter
     /// </summary>
     string? Filter { get; set; }
     /// <summary>
-    /// Value used for fuzzy searching across multiple fields.
+    /// Value used for fuzzy matching across multiple fields.
     /// </summary>
     string? Fuzzy { get; set; }
     /// <summary>
-    /// Restricts fuzzy searching to specific fields.
+    /// Optional field list that limits fuzzy matching.
     /// </summary>
     string? FuzzyColumns { get; set; }
 }

--- a/Monica.AutoModel/Interfaces/IHasRequestSelected.cs
+++ b/Monica.AutoModel/Interfaces/IHasRequestSelected.cs
@@ -3,17 +3,17 @@ namespace Monica.AutoModel.Interfaces;
 public interface IHasRequestSelect
 {
     /// <summary>
-    /// Response field selection that includes only specific fields.
+    /// Response field list that includes only the specified fields.
     /// </summary>
     string? SelectColumns { get; set; }
 
     /// <summary>
-    /// Response field selection that excludes the specified fields. Cannot be used with <see cref="SelectColumns"/>.
+    /// Response field list that excludes the specified fields. Cannot be used with <see cref="SelectColumns"/>.
     /// </summary>
     string? SelectExceptColumns { get; set; }
 
     /// <summary>
-    /// Indicates whether any field selection has been applied.
+    /// Determines whether any field-selection option has been provided.
     /// </summary>
 
     bool HasUsingSelected()

--- a/Monica.AutoModel/Model/AutoField.cs
+++ b/Monica.AutoModel/Model/AutoField.cs
@@ -7,7 +7,7 @@ using Monica.Tool.Extensions;
 namespace Monica.AutoModel.Model;
 
 /// <summary>
-/// AutoModel field configuration.
+/// AutoModel field metadata.
 /// </summary>
 public class AutoField
 {
@@ -19,7 +19,7 @@ public class AutoField
     #region Navigation
 
     /// <summary>
-    /// Navigation-property segments from the root model to this field,
+    /// Navigation-property path segments from the root model to this field,
     /// together with a flag indicating whether each segment is an <c>ICollection</c>.
     /// </summary>
     [JsonIgnore]
@@ -56,7 +56,7 @@ public class AutoField
             var navigationInfo = NavigationProperties.ElementAtOrDefault(navigationIndex++);
             var navigationName = navigationInfo.RefelectName;
             var isCollection = navigationInfo.IsCollection;
-            if (navigationInfo == default) // Reached the actual field; no navigation property remains.
+            if (navigationInfo == default) // Reached the actual field; no navigation segment remains.
             {
                 var fieldName = ReflectionName;
                 if ((TypeSetting.TypeFeatures & ETypeFeatures.IsCollection) != 0)
@@ -144,7 +144,7 @@ public class AutoField
 
     #endregion
     /// <summary>
-    /// Display name of the field. If not specified, the reflected property name is used.
+    /// Display name of the field. Defaults to the reflected property name.
     /// </summary>
     public required string Title { get; set; }
     /// <summary>
@@ -153,12 +153,12 @@ public class AutoField
     public required string ReflectionName { get; set; }
 
     /// <summary>
-    /// Fuzzy-search configuration.
+    /// Fuzzy-match configuration.
     /// </summary>
     public required AutoModelFuzzSetting FuzzSetting { get; set; }
 
     /// <summary>
-    /// Field type configuration.
+    /// Field type metadata.
     /// </summary>
     public required AutoFieldTypeSetting TypeSetting { get; set; }
     /// <summary>
@@ -167,14 +167,14 @@ public class AutoField
     public bool EnableIgnorePrefix { get; set; }
 
     /// <summary>
-    /// Gets the default activation name.
+    /// Gets the default activation name for this field.
     /// </summary>
     public string DefaultActiveName =>
         EnableIgnorePrefix ? ReflectionName : $"{NavigationProperties?.Select(s => s.RefelectName).StringJoin(".").BeIfNotEmpty("{0}.", true)}{ReflectionName}";
     /// <summary>
-    /// Indicates that this field requires client-side evaluation because it cannot be translated to SQL.
+    /// Indicates that this field must be evaluated on the client because it cannot be translated to SQL.
     /// </summary>
-    [Obsolete("暂未实现")]
+    [Obsolete("Not implemented yet.")]
     public bool ShouldUseClientEvaluation { get; set; }
     public override string ToString()
     {

--- a/Monica.AutoModel/Model/AutoTable.cs
+++ b/Monica.AutoModel/Model/AutoTable.cs
@@ -1,7 +1,7 @@
 namespace Monica.AutoModel.Model;
 
 /// <summary>
-/// AutoModel table configuration.
+/// AutoModel table metadata.
 /// </summary>
 public class AutoTable
 {

--- a/Monica.AutoModel/Model/FieldToken.cs
+++ b/Monica.AutoModel/Model/FieldToken.cs
@@ -6,17 +6,17 @@ namespace Monica.AutoModel.Model;
 public class FieldToken(string fieldStr, string conditionStr, string valueStr, int start, int end)
 {
     /// <summary>
-    /// Field activation name in the expression.
+    /// Field activation name in the original expression.
     /// </summary>
     public string FieldStr { get; set; } = fieldStr;
 
     /// <summary>
-    /// Condition token in the expression.
+    /// Condition token in the original expression.
     /// </summary>
     public string ConditionStr { get; set; } = conditionStr;
 
     /// <summary>
-    /// Value token in the expression.
+    /// Value token in the original expression.
     /// </summary>
     public string ValueStr { get; set; } = valueStr;
 
@@ -26,33 +26,36 @@ public class FieldToken(string fieldStr, string conditionStr, string valueStr, i
     public AutoField? FieldInfo { get; set; }
 
     /// <summary>
-    /// Parsed field condition.
+    /// Resolved field condition.
     /// </summary>
     public EFieldConditions Conditions { get; set; }
 
     /// <summary>
-    /// Parsed field-condition features.
+    /// Resolved field-condition features.
     /// </summary>
     public EFieldConditionFeatures Features { get; set; }
 
     /// <summary>
-    /// Converted value object.
+    /// Converted value.
     /// </summary>
     public object? ConvertedValue { get; set; }
 
     /// <summary>
-    /// Start position in the original expression.
+    /// Start index in the original expression.
     /// </summary>
     public int Start { get; set; } = start;
 
     /// <summary>
-    /// End position in the original expression.
+    /// End index in the original expression.
     /// </summary>
     public int End { get; set; } = end;
 
+    /// <summary>
+    /// Generated token expression.
+    /// </summary>
     public string? TokenExpression { get; set; }
     /// <summary>
-    /// Gets the field parameter used in the generated condition expression.
+    /// Gets the field path used in the generated condition expression.
     /// </summary>
     /// <returns>The field parameter expression, or <c>null</c> if the field is unresolved.</returns>
     public string? GetFieldParam()
@@ -76,7 +79,7 @@ public class TokenizerContext(string originExpression)
 
     public string GetFinalExpression()
     {
-        // TODO: Optimize expressions built from tokens at the same logical level.
+        // TODO: Optimize expressions composed from tokens at the same logical level.
         var final = OriginExpression;
         for (var i = Tokens.Count - 1; i >= 0; i--)
         {
@@ -93,14 +96,14 @@ public class TokenizerContext(string originExpression)
 }
 
 /// <summary>
-/// Field-condition features.
+/// Field condition features.
 /// </summary>
 [Flags]
 public enum EFieldConditionFeatures
 {
     None,
     /// <summary>
-    /// Regular expression matching. Not implemented yet.
+    /// Regular-expression matching. Not implemented yet.
     /// </summary>
     UseRegex = 1 << 0,
     /// <summary>
@@ -112,18 +115,18 @@ public enum EFieldConditionFeatures
     /// </summary>
     Multi = 1 << 2,
     /// <summary>
-    /// Fuzzy mode. Enabled by default when <c>like</c> is used and the field type supports it.
+    /// Fuzzy-match mode. Enabled by default when <c>like</c> is used and the field type supports it.
     /// </summary>
     Fuzzy = 1 << 3,
 
     /// <summary>
-    /// Negation. When this flag is set, the condition result is inverted.
+    /// Negates the condition result.
     /// </summary>
     Not = 1 << 4,
 }
 
 /// <summary>
-/// AutoModel field conditions.
+/// Supported AutoModel field conditions.
 /// </summary>
 public enum EFieldConditions
 {
@@ -137,12 +140,12 @@ public enum EFieldConditions
     [KouEnumName("=")]
     Equal,
     /// <summary>
-    /// Pattern match for strings, such as <c>xx%</c>.
+    /// String pattern match, such as <c>xx%</c>.
     /// </summary>
     [KouEnumName("like")]
     Like,
     /// <summary>
-    /// Exists within.
+    /// Included in a value list.
     /// </summary>
     [KouEnumName("in")]
     In,
@@ -177,7 +180,7 @@ public enum EFieldConditions
     [KouEnumName("explike")]
     ExpLike,
     /// <summary>
-    /// Not like.
+    /// Negated pattern match.
     /// </summary>
     [KouEnumName("notlike")]
     NotLike,

--- a/Monica.AutoModel/Model/OtherConvertedResult.cs
+++ b/Monica.AutoModel/Model/OtherConvertedResult.cs
@@ -10,10 +10,9 @@ public class FieldResult
 
 
 /// <summary>
-/// Indicates that this field condition should be skipped, for example when it always evaluates to false.
+/// Marker result indicating that this field condition should be skipped, for example when it always evaluates to false.
 /// </summary>
 public class ResultJumpThisField
 {
     public override string ToString() => nameof(ResultJumpThisField);
 }
-

--- a/Monica.AutoModel/Modules/ModuleAutoModel.cs
+++ b/Monica.AutoModel/Modules/ModuleAutoModel.cs
@@ -18,7 +18,7 @@ public static class ModuleAutoModelBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Registers and configures the AutoModel module.
+        /// Adds and configures the AutoModel module.
         /// </summary>
         public static ModuleAutoModelGuide AddAutoModel(Action<ModuleAutoModelOption>? action = null)
         {
@@ -90,35 +90,35 @@ public class ModuleAutoModelGuide : MoModuleGuide<ModuleAutoModel, ModuleAutoMod
 public class ModuleAutoModelOption : MoModuleOptionWithMinimalApi<ModuleAutoModel>
 {
     /// <summary>
-    /// Global active mode. Only fields marked with <c>AutoField</c> participate in AutoModel.
+    /// Enables global active mode. Only fields marked with <c>AutoField</c> participate in AutoModel.
     /// </summary>
     public bool EnableActiveMode { get; set; }
 
     /// <summary>
-    /// Enables prefix omission for default activation names.
+    /// Allows default activation names to omit prefixes.
     /// </summary>
     public bool EnableIgnorePrefix { get; set; }
 
     /// <summary>
-    /// When prefix omission is enabled for default activation names, automatic adjustment failures do not throw errors.
+    /// When prefix omission is enabled for default activation names, activation-name auto-adjustment failures do not throw exceptions.
     /// </summary>
     public bool EnableIgnorePrefixAutoAdjust { get; set; }
 
     /// <summary>
-    /// Enables debugging mode, for example to show the Expression generated from a filter.
+    /// Enables debugging mode, for example by showing the expression generated from a filter.
     /// </summary>
     public bool EnableDebugging { get; set; }
     /// <summary>
     /// Enables using the field display name as an activation name.
     /// </summary>
-    [Obsolete("暂未实现")]
+    [Obsolete("Not implemented yet.")]
     public bool EnableTitleAsActivateName { get; set; }
 
     public bool DisableAutoIgnorePropertyWithJsonIgnoreAttribute { get; set; }
     public bool DisableAutoIgnorePropertyWithNotMappedAttribute { get; set; }
 
     /// <summary>
-    /// Throws exceptions for unsupported field types.
+    /// Throws when a model contains unsupported field types.
     /// </summary>
     public bool EnableErrorForUnsupportedFieldTypes { get; set; }
 

--- a/Monica.Configuration.UI/Implements/ConfigurationCentreApiProvider.cs
+++ b/Monica.Configuration.UI/Implements/ConfigurationCentreApiProvider.cs
@@ -10,7 +10,8 @@ using ResExtensions = Monica.Tool.Results.ResExtensions;
 namespace Monica.Configuration.UI.Implements;
 
 /// <summary>
-/// Configuration center API provider, uses the status manager of the registration center to obtain the registered service list and call its configuration endpoint
+/// Configuration-center API provider.
+/// Uses the registration-state manager to discover registered services and invoke their configuration endpoints.
 /// </summary>
 public class ConfigurationCentreApiProvider(
     IMoConfigurationModifier modifier,

--- a/Monica.Configuration.UI/Implements/ConfigurationClientApiProvider.cs
+++ b/Monica.Configuration.UI/Implements/ConfigurationClientApiProvider.cs
@@ -8,7 +8,8 @@ using Monica.Tool.Results;
 namespace Monica.Configuration.UI.Implements;
 
 /// <summary>
-/// Configure the client API provider to provide configuration management functions in client mode
+/// Client-side configuration API provider.
+/// Exposes configuration-management operations when running in client mode.
 /// </summary>
 public class ConfigurationClientApiProvider(
     IMoConfigurationModifier modifier,

--- a/Monica.Core/Modularity/Models/EMoModuleKey.cs
+++ b/Monica.Core/Modularity/Models/EMoModuleKey.cs
@@ -1,7 +1,7 @@
 namespace Monica.Core.Modularity.Models;
 
 /// <summary>
-/// Built-in Monica module keys.
+/// Built-in module keys used by Monica.
 /// </summary>
 public enum EMoModuleKey
 {

--- a/Monica.Core/Modularity/Models/ModuleRegisterInfo.cs
+++ b/Monica.Core/Modularity/Models/ModuleRegisterInfo.cs
@@ -143,7 +143,8 @@ public class ModuleRegisterInfo(Type moduleType)
 
         if (ModuleSingleton == null)
         {
-            throw new Exception($"{ModuleType.GetCleanFullName()}模块初始化最终设置失败！未能生成模块单例");
+            throw new Exception(
+                $"Failed to initialize final configuration for module '{ModuleType.GetCleanFullName()}': the module singleton could not be created.");
         }
 
 

--- a/Monica.Dapr/Modules/ModuleDapr.cs
+++ b/Monica.Dapr/Modules/ModuleDapr.cs
@@ -16,7 +16,7 @@ public static class ModuleDaprBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configure the Dapr module
+        /// Registers and configures the Dapr module.
         /// </summary>
         public static ModuleDaprGuide AddDapr(Action<ModuleDaprOption>? action = null)
         {
@@ -48,10 +48,10 @@ public partial class ModuleDapr(ModuleDaprOption option) : MoModule<ModuleDapr, 
                 var res = await daprClient.GetMetadataAsync();
                 await context.Response.WriteAsJsonAsync(res);
             })
-            .WithName("获取Dapr边车元数据")
+            .WithName("Get Dapr sidecar metadata")
             .WithTags(tagName)
-            .WithSummary("获取Dapr边车元数据")
-            .WithDescription("获取Dapr边车元数据");
+            .WithSummary("Gets metadata reported by the Dapr sidecar.")
+            .WithDescription("Returns metadata reported by the Dapr sidecar.");
         });
     }
 

--- a/Monica.Dapr/Modules/ModuleDaprClient.cs
+++ b/Monica.Dapr/Modules/ModuleDaprClient.cs
@@ -19,7 +19,7 @@ public static class ModuleDaprClientBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configuring the DaprClient module
+        /// Registers and configures the Dapr client module.
         /// </summary>
         public static ModuleDaprClientGuide AddDaprClient(Action<ModuleDaprClientOption>? action = null)
         {

--- a/Monica.Dapr/Modules/ModuleDaprEventBus.cs
+++ b/Monica.Dapr/Modules/ModuleDaprEventBus.cs
@@ -16,7 +16,7 @@ namespace Monica.Modules;
 public static class ModuleDaprEventBusBuilderExtensions
 {
     /// <summary>
-    /// Using Dapr as a distributed event bus provider
+    /// Registers Dapr as the distributed event bus provider.
     /// </summary>
     public static ModuleDaprEventBusGuide UseDaprProvider(this ModuleEventBusGuide guide,
         Action<ModuleDaprEventBusOption>? action = null)
@@ -70,11 +70,13 @@ public class ModuleDaprEventBus(ModuleDaprEventBusOption option)
 public class ModuleDaprEventBusGuide : MoModuleGuide<ModuleDaprEventBus, ModuleDaprEventBusOption, ModuleDaprEventBusGuide>
 {
     /// <summary>
-    /// Add Keyed distributed Dapr event bus
-    /// Register the DaprEventBus instance with the specified ServiceKey and the corresponding HostedService
+    /// Registers a keyed Dapr distributed event bus together with its corresponding hosted
+    /// subscription service.
     /// </summary>
-    /// <param name="key">service key</param>
-    /// <param name="configureOptions">Optional Dapr configuration (like different PubSubName)</param>
+    /// <param name="key">Service key.</param>
+    /// <param name="configureOptions">
+    /// Optional Dapr event bus configuration, for example to use a different pub/sub component.
+    /// </param>
     [RequiresPreviewFeatures]
     public ModuleDaprEventBusGuide AddKeyedDaprEventBus(string key, Action<ModuleDaprEventBusOption> configureOptions)
     {

--- a/Monica.Dapr/Modules/ModuleDaprProviderRpcClient.cs
+++ b/Monica.Dapr/Modules/ModuleDaprProviderRpcClient.cs
@@ -40,7 +40,7 @@ public class ModuleDaprProviderRpcClientGuide : MoModuleGuide<ModuleDaprProvider
 public class ModuleDaprProviderRpcClientOption : MoModuleOption<ModuleDaprProviderRpcClient>
 {
     /// <summary>
-    /// RPC interface call timeout
+    /// Timeout applied to RPC calls.
     /// </summary>
     public TimeSpan Timeout { get; set; } =  TimeSpan.FromSeconds(60);
 }

--- a/Monica.Dapr/Modules/ModuleDaprServiceInvocation.cs
+++ b/Monica.Dapr/Modules/ModuleDaprServiceInvocation.cs
@@ -16,7 +16,7 @@ namespace Monica.Modules;
 public static class ModuleDaprServiceInvocationBuilderExtensions
 {
     /// <summary>
-    /// Using Dapr as service call provider
+    /// Registers Dapr as the service invocation provider.
     /// </summary>
     public static ModuleDaprServiceInvocationGuide UseDaprInvocationProvider(
         this ModuleServiceInvocationGuide guide, Action<ModuleDaprServiceInvocationOption>? action = null)
@@ -27,7 +27,7 @@ public static class ModuleDaprServiceInvocationBuilderExtensions
 }
 
 /// <summary>
-/// Dapr service call module
+/// Dapr-based service invocation module.
 /// </summary>
 [ModuleKey(EMoModuleKey.DaprProviderClientConnector)]
 public class ModuleDaprServiceInvocation(ModuleDaprServiceInvocationOption option)
@@ -58,7 +58,7 @@ public class ModuleDaprServiceInvocationOption : MoModuleOption<ModuleDaprServic
 }
 
 /// <summary>
-/// Dapr-based service call connector implementation
+/// Dapr-based service invocation connector.
 /// </summary>
 public class DaprServiceInvocationConnector(
     DaprClient client,
@@ -77,7 +77,7 @@ public class DaprServiceInvocationConnector(
             var res = JsonSerializer.Deserialize<TResponse>(content, jsonSerializerOptionsProvider.SerializerOptions);
             if (res == null)
                 throw new InvocationException(appId, callbackUrl,
-                    new Exception("Json序列化为空"), response);
+                    new Exception("JSON deserialization returned null."), response);
 
             if (res is IResultEnvelope serviceResponse)
             {
@@ -89,14 +89,20 @@ public class DaprServiceInvocationConnector(
         catch (JsonException jsonException)
         {
             var message = jsonException.GetMessageRecursively();
-            logger.LogError(jsonException, "执行{0}服务{1}失败:{2}，Json数据：{3}", appId, callbackUrl, message, content);
-            return Res.Fail(ResStatus.BadRequest, "执行{0}服务{1}失败:{2}，Json数据：{3}", appId, callbackUrl, message, content);
+            logger.LogError(jsonException,
+                "Failed to invoke service '{AppId}' at '{CallbackUrl}': {Message}. JSON payload: {Content}",
+                appId, callbackUrl, message, content);
+            return Res.Fail(ResStatus.BadRequest,
+                "Failed to invoke service '{0}' at '{1}': {2}. JSON payload: {3}",
+                appId, callbackUrl, message, content);
         }
         catch (Exception e)
         {
             var message = e.GetMessageRecursively();
-            logger.LogError(e, "执行{0}服务{1}失败:{2}", appId, callbackUrl, message);
-            return Res.Fail(ResStatus.BadRequest, "执行{0}服务{1}失败:{2}", appId, callbackUrl, message);
+            logger.LogError(e, "Failed to invoke service '{AppId}' at '{CallbackUrl}': {Message}",
+                appId, callbackUrl, message);
+            return Res.Fail(ResStatus.BadRequest, "Failed to invoke service '{0}' at '{1}': {2}",
+                appId, callbackUrl, message);
         }
     }
 
@@ -125,7 +131,7 @@ public class DaprServiceInvocationConnector(
             var res = JsonSerializer.Deserialize<TResponse>(content, jsonSerializerOptionsProvider.SerializerOptions);
             if (res == null)
                 throw new InvocationException(appId, callbackUrl,
-                    new Exception("Json序列化为空"), response);
+                    new Exception("JSON deserialization returned null."), response);
 
             if (res is IResultEnvelope serviceResponse)
             {
@@ -136,14 +142,20 @@ public class DaprServiceInvocationConnector(
         catch (JsonException jsonException)
         {
             var message = jsonException.GetMessageRecursively();
-            logger.LogError(jsonException, "执行{0}服务{1}失败:{2}，Json数据：{3}", appId, callbackUrl, message, content);
-            return Res.Fail(ResStatus.BadRequest, "执行{0}服务{1}失败:{2}，Json数据：{3}", appId, callbackUrl, message, content);
+            logger.LogError(jsonException,
+                "Failed to invoke service '{AppId}' at '{CallbackUrl}': {Message}. JSON payload: {Content}",
+                appId, callbackUrl, message, content);
+            return Res.Fail(ResStatus.BadRequest,
+                "Failed to invoke service '{0}' at '{1}': {2}. JSON payload: {3}",
+                appId, callbackUrl, message, content);
         }
         catch (Exception e)
         {
             var message = e.GetMessageRecursively();
-            logger.LogError(e, "执行{0}服务{1}失败:{2}", appId, callbackUrl, message);
-            return Res.Fail(ResStatus.BadRequest, "执行{0}服务{1}失败:{2}", appId, callbackUrl, message);
+            logger.LogError(e, "Failed to invoke service '{AppId}' at '{CallbackUrl}': {Message}",
+                appId, callbackUrl, message);
+            return Res.Fail(ResStatus.BadRequest, "Failed to invoke service '{0}' at '{1}': {2}",
+                appId, callbackUrl, message);
         }
     }
 

--- a/Monica.Dapr/Modules/ModuleDaprStateStore.cs
+++ b/Monica.Dapr/Modules/ModuleDaprStateStore.cs
@@ -21,12 +21,12 @@ public static class ModuleDaprStateStoreBuilderExtensions
     }
     
     /// <summary>
-    /// Add Dapr state store as Keyed StateStore provider
+    /// Registers Dapr state store as a keyed state store provider.
     /// </summary>
-    /// <param name="guide">StateStore Module Guide</param>
-    /// <param name="serviceKey">The service key that identifies this StateStore instance</param>
-    /// <param name="configureOptions">Dapr state storage configuration delegate</param>
-    /// <returns>StateStore module guide example to support chained calls</returns>
+    /// <param name="guide">The StateStore module guide.</param>
+    /// <param name="serviceKey">The service key that identifies this state store instance.</param>
+    /// <param name="configureOptions">Delegate that configures the Dapr state store.</param>
+    /// <returns>The same StateStore module guide to support chaining.</returns>
     public static ModuleStateStoreGuide AddKeyedDaprStateStore(
         this ModuleStateStoreGuide guide,
         string serviceKey,
@@ -92,14 +92,15 @@ public class
 public class ModuleDaprStateStoreOption : MoModuleOption<ModuleDaprStateStore>
 {
     /// <summary>
-    /// Dapr StateStore name. It needs to be consistent with the name definition in the metadata of the Dapr StateStore.yaml file.
+    /// Name of the Dapr state store. Must match the <c>name</c> field in the Dapr state store
+    /// component YAML metadata.
     /// </summary>
     [Required]
     public string StateStoreName { get; set; } = null!;
 
     /// <summary>
-    /// The number of concurrent get operations the Dapr runtime will issue to the state store. a value equal to or smaller than 0 means max parallelism.
+    /// Number of concurrent get operations issued by the Dapr runtime to the state store. Values
+    /// less than or equal to 0 remove the limit.
     /// </summary>
     public int? DefaultBulkParallelism { get; set; } 
 }
-

--- a/Monica.DataChannel/BuildInMiddlewares/DataTransformer/DataTransformerCore.cs
+++ b/Monica.DataChannel/BuildInMiddlewares/DataTransformer/DataTransformerCore.cs
@@ -48,7 +48,7 @@ public abstract class UniDataTransformerMiddlewareBase<TConverterCore, TSource, 
     {
         if (source is TSource from) return Convert(from);
         throw new InvalidOperationException(
-            $"Can not transform {source?.GetType()} to {typeof(TDestination)} in {nameof(TConverterCore)}");
+            $"Cannot transform {source?.GetType()} to {typeof(TDestination)} in {nameof(TConverterCore)}");
     }
 
     public abstract TDestination Convert(TSource data);
@@ -78,7 +78,7 @@ public abstract class BiDataTransformerMiddlewareBase<TConverterCore, T1, T2> :
             T1 t1 => Convert(t1),
             T2 t2 => Convert(t2),
             _ => throw new InvalidOperationException(
-                $"Can not transform {source?.GetType()} to {typeof(T1)} or {typeof(T2)} in {nameof(TConverterCore)}")
+                $"Cannot transform {source?.GetType()} to {typeof(T1)} or {typeof(T2)} in {nameof(TConverterCore)}")
         };
     }
 }

--- a/Monica.DataChannel/UIDataChannel/Services/DataChannelUIService.cs
+++ b/Monica.DataChannel/UIDataChannel/Services/DataChannelUIService.cs
@@ -9,7 +9,7 @@ namespace Monica.DataChannel.UIDataChannel.Services;
 /// Provides the UI service surface for managing DataChannels.
 /// </summary>
 /// <remarks>
-/// Initializes the service dependencies.
+/// The primary constructor receives the dependencies required by the UI service.
 /// </remarks>
 /// <param name="manager">Manager that exposes registered DataChannels.</param>
 /// <param name="logger">Logger used for auditing and error reporting.</param>

--- a/Monica.DependencyInjection/DynamicProxy/DynamicProxyExtensions.cs
+++ b/Monica.DependencyInjection/DynamicProxy/DynamicProxyExtensions.cs
@@ -240,7 +240,7 @@ public static class MicrosoftDependencyInjectionDynamicProxyExtensions
             }
         }
 
-        //Shouldn't the same type of Interceptor be registered multiple times?
+        // Avoid registering the same interceptor type more than once.
         IInterceptor[] GetInterceptors(IServiceProvider provider, RegisterContext context)
         {
             var types = context.InterceptorTypes;
@@ -293,7 +293,7 @@ public static class MicrosoftDependencyInjectionDynamicProxyExtensions
                     var interceptors = GetInterceptors(provider, context);
                     var targetFromFactory = factory.Invoke(provider);
                     object? proxiedObject;
-                    //TODO cannot implement property injection because factory method instantiation can only be executed once.
+                    // TODO: Property injection is not supported here because the factory result is created only once.
                     switch (context.Kind)
                     {
                         case EDynamicProxyKind.ClassProxy:
@@ -319,7 +319,8 @@ public static class MicrosoftDependencyInjectionDynamicProxyExtensions
         }
         void AddNormalRegister(RegisterContext context)
         {
-            //Big Pitfall: If the Controller does not use AddControllersAsServices, the Controller cannot be dynamically proxied.
+            // Important: Controllers must be added via AddControllersAsServices; otherwise, they
+            // cannot be proxied dynamically.
             collection.Add(new ServiceDescriptor(context.OldDescriptor.ServiceType, context.OldDescriptor.ServiceKey,
                 (provider, o) =>
                 {
@@ -368,7 +369,8 @@ public static class MicrosoftDependencyInjectionDynamicProxyExtensions
 public enum EDynamicProxyKind
 {
     /// <summary>
-    /// Proxy class methods marked as virtual. TODO Currently only supports virtual method proxies
+    /// Creates proxies for virtual members on concrete classes. Currently only virtual methods are
+    /// supported.
     /// </summary>
     ClassProxy,
     /// <summary>

--- a/Monica.DependencyInjection/Implements/ConventionalRegistrarBase.cs
+++ b/Monica.DependencyInjection/Implements/ConventionalRegistrarBase.cs
@@ -24,7 +24,7 @@ public class DefaultConventionalRegistrar(ModuleDependencyInjectionOption option
     /// <param name="type">The type to be registered.</param>
     public virtual void AddType(IServiceCollection services, Type type)
     {
-        //TODO supports generic automatic registration, but requires configuration.
+        // TODO: Support automatic registration of generic types through configuration.
         if(type is not { IsClass: true, IsAbstract: false, IsGenericType: false }) return;
 
         var dependencyAttribute = GetDependencyAttributeOrNull(type);
@@ -45,17 +45,20 @@ public class DefaultConventionalRegistrar(ModuleDependencyInjectionOption option
         {
             if (exposedServiceAndKeyedServiceTypes.Count == 0)
             {
-                logger.LogError("未能自动注册成功的类型：{name} {lifetime}", typeName, lifeTime);
+                logger.LogError("Failed to auto-register type: {TypeName} {Lifetime}", typeName, lifeTime);
             }
             else if (exposedServiceAndKeyedServiceTypes is [{ServiceType: { } typeSelf}] && typeSelf.Name == typeName)
             {
                 
-                logger.LogWarning("仅注册了本身类型：{name} {lifetime}", typeName, lifeTime);
+                logger.LogWarning("Only the concrete type was registered: {TypeName} {Lifetime}", typeName, lifeTime);
             }
             else
             {
                 
-                logger.LogInformation("自动注册：{name}->{serviceType} {lifetime}", typeName,$"[{exposedServiceAndKeyedServiceTypes.Select(p=>p.ServiceType.Name).StringJoin(", ")}]", lifeTime);
+                logger.LogInformation("Auto-registered: {TypeName}->{ServiceTypes} {Lifetime}",
+                    typeName,
+                    $"[{exposedServiceAndKeyedServiceTypes.Select(p => p.ServiceType.Name).StringJoin(", ")}]",
+                    lifeTime);
             }
         }
         
@@ -160,7 +163,7 @@ public class DefaultConventionalRegistrar(ModuleDependencyInjectionOption option
         List<ServiceIdentifier> allExposingServiceTypes,
         ServiceLifetime lifeTime)
     {
-        //TODO generic automatic registration
+        // TODO: Support automatic registration of generic types.
         //if (implementationType.IsGenericType)
         //{
         //    implementationType = implementationType.GetGenericTypeDefinition();
@@ -171,7 +174,7 @@ public class DefaultConventionalRegistrar(ModuleDependencyInjectionOption option
         //    exposingServiceType = exposingServiceType.GetGenericTypeDefinition();
         //}
 
-        //TODO Study whether this paragraph is necessary
+        // TODO: Revisit whether this redirection block is still necessary.
         if (lifeTime.EqualsAny(ServiceLifetime.Singleton, ServiceLifetime.Scoped))
         {
             var redirectedType = GetRedirectedTypeOrNull(

--- a/Monica.DomainDrivenDesign/Attributes/OverrideServiceAttribute.cs
+++ b/Monica.DomainDrivenDesign/Attributes/OverrideServiceAttribute.cs
@@ -4,13 +4,16 @@ namespace Monica.DomainDrivenDesign.Attributes;
 
 
 /// <summary>
-/// Marks the method that should eventually be exposed by a service, allowing MoCrudAppService{TEntity,TEntityDto,TKey,TGetListInput,TRepository} and similar application services to override a base signature via `new` or a different parameter list while inheriting the return-type override semantics.
+/// Marks the method that should be exposed on the generated service contract.
+/// Use this when an application service hides a base member with <c>new</c> or a different
+/// signature but still wants that member to win during contract generation.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 public class OverrideServiceAttribute(int order = 0) : Attribute
 {
     /// <summary>
-    /// When multiple members with the same signature exist in the current class or its base classes, the highest order value determines which one appears on the generated interface.
+    /// When multiple members with the same signature exist, the member with the highest order is
+    /// selected for the generated interface.
     /// </summary>
     public int Order { get; set; } = order;
 }

--- a/Monica.DomainDrivenDesign/AutoController/Components/MoEndpointFilterResult.cs
+++ b/Monica.DomainDrivenDesign/AutoController/Components/MoEndpointFilterResult.cs
@@ -6,7 +6,7 @@ using Monica.Tool.Results;
 namespace Monica.DomainDrivenDesign.AutoController.Components;
 
 /// <summary>
-/// Endpoint filter variant for Minimal API.
+/// Endpoint filter variant for Minimal API endpoints.
 /// </summary>
 public class MoEndpointFilterResult : IEndpointFilter
 {
@@ -17,10 +17,11 @@ public class MoEndpointFilterResult : IEndpointFilter
         {
             context.HttpContext.Response.StatusCode =
                 (int?) response.ToHttpStatusCode() ?? (int) HttpStatusCode.BadRequest;
+
+            // Minimal API serializes ObjectResult differently from MVC controllers.
+            // MVC returns ObjectResult.Value, while Minimal API would serialize the ObjectResult
+            // wrapper itself. Returning Value keeps the payload aligned with MVC behavior.
             return objResult.Value;
-            // Important: Minimal API serializes differently from MVC controllers.
-            // MVC returns ObjectResult.Value, while Minimal API serializes the ObjectResult itself.
-            // Later note: Minimal API should return Microsoft.AspNetCore.Http.Results; Results.Json() can replace ObjectResult.
         }
 
         return result;

--- a/Monica.DomainDrivenDesign/AutoController/Features/MoConventionalCrudControllerFeatureProvider.cs
+++ b/Monica.DomainDrivenDesign/AutoController/Features/MoConventionalCrudControllerFeatureProvider.cs
@@ -25,11 +25,15 @@ public class MoConventionalCrudControllerFeatureProvider(ILogger<MoConventionalC
         {
             if (typeInfo.Name.EndsWith(options.Value.CrudControllerPostfix))
             {
-                logger.LogInformation("自动注册 CRUD Controller：{name}", typeInfo.Name);
+                logger.LogInformation("Automatically registered CRUD controller: {ControllerName}",
+                    typeInfo.Name);
             }
             else
             {
-                logger.LogError("自动注册 CRUD Controller：{name} 失败，因为与要求后缀「{postfix}」不匹配", typeInfo.Name, options.Value.CrudControllerPostfix);
+                logger.LogError(
+                    "Failed to auto-register CRUD controller '{ControllerName}' because it does not match the required suffix '{RequiredSuffix}'.",
+                    typeInfo.Name,
+                    options.Value.CrudControllerPostfix);
             }
             return true;
         }

--- a/Monica.DomainDrivenDesign/AutoCrud/Interfaces/LimitedResultRequestDto.cs
+++ b/Monica.DomainDrivenDesign/AutoCrud/Interfaces/LimitedResultRequestDto.cs
@@ -27,7 +27,9 @@ public class LimitedResultRequestDto : IHasRequestLimitedResult, IValidatableObj
     public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (MaxResultCount > MaxMaxResultCount)
-            yield return new ValidationResult($"{nameof(MaxResultCount)}超过{MaxMaxResultCount}限制", [nameof(MaxResultCount)]);
+            yield return new ValidationResult(
+                $"{nameof(MaxResultCount)} exceeds the limit of {MaxMaxResultCount}.",
+                [nameof(MaxResultCount)]);
         //yield return new ValidationResult((string) validationContext.GetRequiredService<IStringLocalizer<AbpDddApplicationContractsResource>>()["MaxResultCountExceededExceptionMessage", new object[4]
         //    {
         //        (object) "MaxResultCount",

--- a/Monica.DomainDrivenDesign/AutoCrud/MoCrudAppService.cs
+++ b/Monica.DomainDrivenDesign/AutoCrud/MoCrudAppService.cs
@@ -196,9 +196,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return $"未找到相应的{name}";
+            return $"{name} was not found.";
         }
-        return "未找到相应数据";
+        return "The requested data was not found.";
     }
     /// <summary>
     /// Creates the standard success response after an entity update.
@@ -209,9 +209,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return Res.Ok($"{name}更新成功");
+            return Res.Ok($"{name} updated successfully");
         }
-        return Res.Ok($"更新成功:{dto.Id}");
+        return Res.Ok($"Updated successfully: {dto.Id}");
     }
     /// <summary>
     /// Creates the standard success response after an entity update.
@@ -222,9 +222,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return Res.Ok($"{name}更新成功");
+            return Res.Ok($"{name} updated successfully");
         }
-        return Res.Ok($"更新成功:{entityId}");
+        return Res.Ok($"Updated successfully: {entityId}");
     }
     /// <summary>
     /// Creates the standard failure response for an entity update.
@@ -235,9 +235,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return $"{name}更新失败";
+            return $"{name} update failed.";
         }
-        return "更新失败";
+        return "Update failed.";
     }
     /// <summary>
     /// Creates the standard success response after an entity is created.
@@ -248,9 +248,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return Res.Ok($"{name}新增成功:{dto.Id}");
+            return Res.Ok($"{name} created successfully: {dto.Id}");
         }
-        return Res.Ok($"新增成功:{dto.Id}");
+        return Res.Ok($"Created successfully: {dto.Id}");
     }
     /// <summary>
     /// Creates the standard success response after an entity is created.
@@ -261,9 +261,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return Res.Ok($"{name}新增成功:{entityId}");
+            return Res.Ok($"{name} created successfully: {entityId}");
         }
-        return Res.Ok($"新增成功:{entityId}");
+        return Res.Ok($"Created successfully: {entityId}");
     }
     /// <summary>
     /// Creates the standard failure response for entity creation.
@@ -273,9 +273,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return $"{name}新增失败";
+            return $"{name} creation failed.";
         }
-        return "新增失败";
+        return "Creation failed.";
     }
     /// <summary>
     /// Creates the standard success response after an entity is deleted.
@@ -286,9 +286,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return Res.Ok($"{name}删除成功:{id}");
+            return Res.Ok($"{name} deleted successfully: {id}");
         }
-        return Res.Ok($"删除成功:{id}");
+        return Res.Ok($"Deleted successfully: {id}");
     }
     /// <summary>
     /// Creates the standard failure response for entity deletion.
@@ -298,9 +298,9 @@ public abstract class MoCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto
     {
         if (EntityName is { } name)
         {
-            return $"{name}删除失败";
+            return $"{name} deletion failed.";
         }
-        return "删除失败";
+        return "Deletion failed.";
     }
     #endregion
 }

--- a/Monica.DomainDrivenDesign/ExceptionHandler/ValidationExceptionMapper.cs
+++ b/Monica.DomainDrivenDesign/ExceptionHandler/ValidationExceptionMapper.cs
@@ -18,7 +18,7 @@ internal class ValidationExceptionMapper : IExceptionResponseMapper
         switch (exception)
         {
             case MoValidationException validationException:
-                response = Res.Fail("接口请求参数校验失败", ResStatus.ValidateError)
+                response = Res.Fail("Request parameter validation failed.", ResStatus.ValidateError)
                     .AppendMetadata("error", validationException.ValidationErrors);
                 return true;
             default:

--- a/Monica.DomainDrivenDesign/Modules/ModuleAutoControllers.cs
+++ b/Monica.DomainDrivenDesign/Modules/ModuleAutoControllers.cs
@@ -24,7 +24,7 @@ public static class ModuleAutoControllersBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configure the AutoControllers module.
+        /// Registers and configures the AutoControllers module.
         /// </summary>
         public static ModuleAutoControllersGuide AddAutoControllers(Action<ModuleAutoControllersOption>? action = null, Action<MoCrudControllerOption>? crudOptionAction = null)
         {

--- a/Monica.DomainDrivenDesign/Modules/ModuleDomainDrivenDesign.cs
+++ b/Monica.DomainDrivenDesign/Modules/ModuleDomainDrivenDesign.cs
@@ -26,7 +26,8 @@ public class ModuleDomainDrivenDesign(ModuleDomainDrivenDesignOption option) : M
                 if (c.ImplementationType.IsAssignableTo<IMoDomainService>() ||
                     c.ImplementationType.IsAssignableTo<IMoApplicationService>())
                 {
-                    Logger.LogDebug($"service inject: {c.ImplementationType.FullName}");
+                    Logger.LogDebug("Injecting service provider into {ImplementationType}",
+                        c.ImplementationType.FullName);
                     return true;
                 }
 
@@ -59,7 +60,8 @@ public static class ModuleDomainDrivenDesignBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configure the DomainDrivenDesign module (this module also depends on AutoController.Generator).
+        /// Registers and configures the DomainDrivenDesign module. This module also depends on
+        /// AutoController.Generator.
         /// </summary>
         public static ModuleDomainDrivenDesignGuide AddDomainDrivenDesign(Action<ModuleDomainDrivenDesignOption>? action = null)
         {

--- a/Monica.DomainDrivenDesign/Modules/ModuleRpcClient.cs
+++ b/Monica.DomainDrivenDesign/Modules/ModuleRpcClient.cs
@@ -22,7 +22,7 @@ public static class ModuleRpcClientBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configure the RpcClient module.
+        /// Registers and configures the RPC client module.
         /// </summary>
         public static ModuleRpcClientGuide AddRpcClient(Action<ModuleRpcClientOption>? action = null)
         {
@@ -177,7 +177,7 @@ public class ModuleRpcClientGuide : MoModuleGuide<ModuleRpcClient, ModuleRpcClie
 public class ModuleRpcClientOption : MoModuleOption<ModuleRpcClient>
 {
     /// <summary>
-    /// Enable gRPC client registration (HttpClient is used by default).
+    /// Registers RPC clients through gRPC instead of HttpClient.
     /// </summary>
     public bool UseGrpc { get; set; }
 
@@ -201,10 +201,10 @@ public class AuthenticationDelegatingHandler(IHttpContextAccessor httpContextAcc
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // 1. Acquire the current HttpContext
+        // Try to reuse the active request context when the call originates from the frontend.
         var context = httpContextAccessor.HttpContext;
 
-        if (context != null)// request initiated from the frontend
+        if (context != null) // Request initiated from the frontend.
         {
             if (context.Request.Headers.Authorization is { } authorization && !string.IsNullOrWhiteSpace(authorization.ToString()))
             {
@@ -224,13 +224,13 @@ public class AuthenticationDelegatingHandler(IHttpContextAccessor httpContextAcc
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
         }
-        else // request initiated from the backend
+        else // Request initiated from the backend.
         {
             var token = systemUserManager.GetTokenOfCurSystemUser();
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
-        // 4. Continue sending the request
+        // Continue sending the request.
         return await base.SendAsync(request, cancellationToken);
     }
 }

--- a/Monica.DomainDrivenDesign/Modules/ModuleSwagger.cs
+++ b/Monica.DomainDrivenDesign/Modules/ModuleSwagger.cs
@@ -38,7 +38,7 @@ public class ModuleSwagger(ModuleSwaggerOption option) : MoModule<ModuleSwagger,
     {
         services.AddSwaggerGen(options =>
         {
-            // // Add a filter that maps ApiExplorer.GroupName values to Swagger tags.
+            // Add a filter that maps ApiExplorer.GroupName values to Swagger tags.
             // options.OperationFilter<GroupNameToTagsOperationFilter>();
             
             options.SwaggerDoc(Option.Version, new OpenApiInfo
@@ -79,7 +79,9 @@ public class ModuleSwagger(ModuleSwaggerOption option) : MoModule<ModuleSwagger,
                     }
                     else if (!name.StartsWith(nameof(Monica)))
                     {
-                        Logger.LogWarning($"Swagger XML file not found: {filePath}, you need to add <GenerateDocumentationFile>True</GenerateDocumentationFile> into your .csproj file to generate swagger documents");
+                        Logger.LogWarning(
+                            "Swagger XML file not found: {FilePath}. Enable <GenerateDocumentationFile>True</GenerateDocumentationFile> in the project file to generate Swagger documentation.",
+                            filePath);
                     }
                 }
 
@@ -135,7 +137,7 @@ public static class ModuleSwaggerBuilderExtensions
     extension(Mo)
     {
         /// <summary>
-        /// Configure the Swagger module.
+        /// Registers and configures the Swagger module.
         /// </summary>
         public static ModuleSwaggerGuide AddSwagger(Action<ModuleSwaggerOption>? action = null)
         {

--- a/Monica.EventBus/Abstractions/Handlers/ActionEventHandlerFactory.cs
+++ b/Monica.EventBus/Abstractions/Handlers/ActionEventHandlerFactory.cs
@@ -3,7 +3,7 @@
 /// Adapter that allows a delegate to be used as an <see cref="IMoLocalEventHandler{TEvent}"/>
 /// implementation.
 /// </summary>
-/// <typeparam name="TEvent">Event type</typeparam>
+/// <typeparam name="TEvent">Event type.</typeparam>
 public class ActionEventHandler<TEvent> : IMoLocalEventHandler<TEvent>
 {
     /// <summary>
@@ -52,7 +52,7 @@ internal class ActionEventHandlerFactory<TEvent>(Func<TEvent, Task> action) : IE
 
         public void Dispose()
         {
-            // Action handlers don't need disposal
+            // Delegate-based handlers do not require disposal.
         }
     }
 }

--- a/Monica.EventBus/Abstractions/LocalEventBusBase.cs
+++ b/Monica.EventBus/Abstractions/LocalEventBusBase.cs
@@ -19,7 +19,7 @@ public abstract class LocalEventBusBase(
     : EventBusBase(serviceScopeFactory, eventHandlerInvoker, subscriptionManager, logger, serviceKey), IMoLocalEventBus
 {
     /// <summary>
-    /// For local event bus, publishing = directly triggering handlers.
+    /// For the local event bus, publishing means triggering handlers directly.
     /// </summary>
     public override async Task PublishAsync(Type eventType, object eventData, string? topicName = null, CancellationToken cancellationToken = default)
     {
@@ -28,7 +28,7 @@ public abstract class LocalEventBusBase(
     }
 
     /// <summary>
-    /// For local event bus, bulk publishing = triggering handlers for each event.
+    /// For the local event bus, bulk publishing means triggering handlers for each event.
     /// </summary>
     public override async Task BulkPublishAsync(Type eventType, IEnumerable<object> eventDataList, string? topicName = null, CancellationToken cancellationToken = default)
     {

--- a/translation-review-progress.md
+++ b/translation-review-progress.md
@@ -17,7 +17,8 @@
 - [x] Synced latest remote source.
 - [x] Created dedicated review branch.
 - [x] Located translation commit/range.
-- [~] Completed batch 1 review (Monica.AI module in progress).
+- [x] Completed batch 1 review (`Monica.AI/*`).
+- [~] Completed batch 2 review (`Monica.AutoModel/*`, `Monica.Configuration*`, `Monica.DataChannel/*`) — ongoing.
 - [ ] Completed full repository translation review.
 
 ## Findings
@@ -29,3 +30,7 @@
   - `输入 Token 数量` -> `Enter the number of Tokens` (corrected to `Number of input tokens`)
 - Batch 1 focus: `Monica.AI/*` files with obvious machine-translation artifacts and unnatural API/XML-doc phrasing.
 - Review strategy: prioritize files with obviously weak machine-translation patterns first, then continue module-by-module until the entire commit range is covered.
+- Batch 2 observations:
+  - Some XML docs were grammatically correct but semantically awkward in framework/API contexts; these are being rewritten for idiomatic .NET documentation style rather than left as literal translations.
+  - A few untranslated Chinese strings still remained inside developer-facing attributes/messages (for example `Obsolete` text), which are being normalized to English on the review branch.
+  - Several comments used unnatural wording such as "Configure the client API provider..." or "registration center"; these are being corrected to clearer domain language such as "client-side configuration API provider" and "registration-state manager".

--- a/translation-review-progress.md
+++ b/translation-review-progress.md
@@ -3,7 +3,7 @@
 - Branch: `kou/review-comment-translation-quality`
 - Base branch: `dev`
 - Goal: Review and improve the recent repository-wide translation from Chinese comments/annotations to English, preserving or improving original semantic context.
-- Status: started
+- Status: ongoing
 
 ## Plan
 
@@ -18,7 +18,7 @@
 - [x] Created dedicated review branch.
 - [x] Located translation commit/range.
 - [x] Completed batch 1 review (`Monica.AI/*`).
-- [~] Completed batch 2 review (`Monica.AutoModel/*`, `Monica.Configuration*`, `Monica.DataChannel/*`) — ongoing.
+- [x] Completed batch 2 review (`Monica.AutoModel/*`, `Monica.Configuration*`, `Monica.DataChannel/*`).
 - [ ] Completed full repository translation review.
 
 ## Findings
@@ -34,3 +34,7 @@
   - Some XML docs were grammatically correct but semantically awkward in framework/API contexts; these are being rewritten for idiomatic .NET documentation style rather than left as literal translations.
   - A few untranslated Chinese strings still remained inside developer-facing attributes/messages (for example `Obsolete` text), which are being normalized to English on the review branch.
   - Several comments used unnatural wording such as "Configure the client API provider..." or "registration center"; these are being corrected to clearer domain language such as "client-side configuration API provider" and "registration-state manager".
+- AutoModel follow-up observations:
+  - Terminology such as "activation name", "field selection", "snapshot", and "fuzzy match" needed another consistency pass so the module reads like native English instead of literal machine translation.
+  - The remaining AutoModel `Obsolete` attribute messages were still Chinese and have been normalized to `Not implemented yet.`.
+  - PR `#4` was checked on 2026-03-28; its only recorded review feedback was the earlier Monica.AI wording feedback already addressed in `1f7f556c`, with no new actionable comments for the remaining modules.

--- a/translation-review-progress.md
+++ b/translation-review-progress.md
@@ -19,6 +19,7 @@
 - [x] Located translation commit/range.
 - [x] Completed batch 1 review (`Monica.AI/*`).
 - [x] Completed batch 2 review (`Monica.AutoModel/*`, `Monica.Configuration*`, `Monica.DataChannel/*`).
+- [x] Completed batch 3 review (`Monica.Core/*`, `Monica.Dapr/*`, `Monica.DependencyInjection/*`, `Monica.EventBus/*`).
 - [ ] Completed full repository translation review.
 
 ## Findings
@@ -38,3 +39,11 @@
   - Terminology such as "activation name", "field selection", "snapshot", and "fuzzy match" needed another consistency pass so the module reads like native English instead of literal machine translation.
   - The remaining AutoModel `Obsolete` attribute messages were still Chinese and have been normalized to `Not implemented yet.`.
   - PR `#4` was checked on 2026-03-28; its only recorded review feedback was the earlier Monica.AI wording feedback already addressed in `1f7f556c`, with no new actionable comments for the remaining modules.
+- Batch 3 focus:
+  - Next review batch is the smaller infrastructure slice: `Monica.Core/*`, `Monica.Dapr/*`, `Monica.DependencyInjection/*`, and `Monica.EventBus/*`.
+  - Early review findings in this batch include awkward “Using X as provider” summaries, literal TODO/comment translations, and a few leftover Chinese developer-facing strings in endpoint metadata, logs, and exception text.
+- Batch 3 observations:
+  - Dapr module docs needed idiomatic builder/facade wording such as “Registers Dapr as the ... provider” instead of literal “Using Dapr as ...”.
+  - A few developer-facing strings had been missed by the original translation commit, including Dapr endpoint metadata, service-invocation error text, DI auto-registration logs, and one core module initialization exception.
+  - EventBus files in this batch mostly needed small cleanup passes for XML-doc polish and comment readability rather than semantic rewrites.
+  - `git diff --check` passed after the batch; `dotnet` and `wslpath` are still unavailable in the environment, so build verification remains unavailable.

--- a/translation-review-progress.md
+++ b/translation-review-progress.md
@@ -20,6 +20,7 @@
 - [x] Completed batch 1 review (`Monica.AI/*`).
 - [x] Completed batch 2 review (`Monica.AutoModel/*`, `Monica.Configuration*`, `Monica.DataChannel/*`).
 - [x] Completed batch 3 review (`Monica.Core/*`, `Monica.Dapr/*`, `Monica.DependencyInjection/*`, `Monica.EventBus/*`).
+- [x] Completed batch 4 review (`Monica.DomainDrivenDesign/*`).
 - [ ] Completed full repository translation review.
 
 ## Findings
@@ -47,3 +48,7 @@
   - A few developer-facing strings had been missed by the original translation commit, including Dapr endpoint metadata, service-invocation error text, DI auto-registration logs, and one core module initialization exception.
   - EventBus files in this batch mostly needed small cleanup passes for XML-doc polish and comment readability rather than semantic rewrites.
   - `git diff --check` passed after the batch; `dotnet` and `wslpath` are still unavailable in the environment, so build verification remains unavailable.
+- Batch 4 observations:
+  - `Monica.DomainDrivenDesign/*` still contained a mix of literal builder-summary translations and entirely untranslated developer-facing strings in CRUD response templates, validation errors, and auto-controller registration logs.
+  - The `OverrideServiceAttribute` and related auto-controller comments needed simplification to describe the contract-generation behavior directly instead of mirroring the original Chinese structure.
+  - A repository-wide Chinese-text scan for `Monica.DomainDrivenDesign/*` returned clean after the batch, and `git diff --check` still passed.


### PR DESCRIPTION
## Summary\n- continue the repository-wide translation quality review after the earlier AI-focused pass\n- refine translated XML docs/comments in Monica.Configuration, Monica.DataChannel, and Monica.AutoModel\n- normalize leftover awkward machine-translated wording and untranslated developer-facing strings\n\n## Included commits\n- 579bccca docs: refine translation quality in config and data-channel docs\n- 535b0685 docs: refine Monica.AutoModel translation quality\n\n## Notes\n- this continues the review of translation commit 3238f77a\n- focus remains on preserving original technical meaning while improving English quality and .NET/XML doc style\n- branch work is still ongoing and more review batches may be added