### PR TITLE
fix(ui): clean up theme dialog title

### DIFF
--- a/Monica.UI/Localization/SharedResource/en-US.json
+++ b/Monica.UI/Localization/SharedResource/en-US.json
@@ -8,7 +8,49 @@
     "DarkMode": "Dark Mode",
     "CurrentTheme": "Current Theme",
     "Dark": "Dark",
-    "Light": "Light"
+    "Light": "Light",
+    "Options": {
+      "mudblazor": {
+        "Name": "MudBlazor",
+        "Description": "Original MudBlazor styling"
+      },
+      "default": {
+        "Name": "Default",
+        "Description": "Classic Material look"
+      },
+      "glassmorphic": {
+        "Name": "Glassmorphic",
+        "Description": "Soft glass panels with blur"
+      },
+      "neonpulse": {
+        "Name": "Neon Pulse",
+        "Description": "Bright neon accents with energy"
+      },
+      "fresh": {
+        "Name": "Fresh",
+        "Description": "Light mint colors and a calm feel"
+      },
+      "aurora-flow": {
+        "Name": "Aurora Flow",
+        "Description": "Aurora gradients with a glass feel"
+      },
+      "ink-landscape": {
+        "Name": "Ink Landscape",
+        "Description": "Ink-wash style with quiet contrast"
+      },
+      "macaron-sweet": {
+        "Name": "Macaron Sweet",
+        "Description": "Pastel colors with a playful tone"
+      },
+      "deep-ocean": {
+        "Name": "Deep Ocean",
+        "Description": "Deep sea blues with a calm glow"
+      },
+      "vintage-press": {
+        "Name": "Vintage Press",
+        "Description": "Warm paper tones and retro print"
+      }
+    }
   },
   "Layout": {
     "SearchTooltip": "Search (Ctrl+K)",

--- a/Monica.UI/Localization/SharedResource/zh-CN.json
+++ b/Monica.UI/Localization/SharedResource/zh-CN.json
@@ -8,7 +8,49 @@
     "DarkMode": "深色模式",
     "CurrentTheme": "当前主题",
     "Dark": "深色",
-    "Light": "浅色"
+    "Light": "浅色",
+    "Options": {
+      "mudblazor": {
+        "Name": "MudBlazor 默认",
+        "Description": "保留原始 MudBlazor 风格"
+      },
+      "default": {
+        "Name": "默认主题",
+        "Description": "经典的 Material 风格"
+      },
+      "glassmorphic": {
+        "Name": "毛玻璃",
+        "Description": "柔和玻璃质感与模糊效果"
+      },
+      "neonpulse": {
+        "Name": "霓虹脉冲",
+        "Description": "明亮霓虹配色，节奏感更强"
+      },
+      "fresh": {
+        "Name": "小清新",
+        "Description": "薄荷浅色调，清爽安静"
+      },
+      "aurora-flow": {
+        "Name": "极光流彩",
+        "Description": "极光渐变配合轻盈玻璃感"
+      },
+      "ink-landscape": {
+        "Name": "墨韵山水",
+        "Description": "水墨留白风格，沉静克制"
+      },
+      "macaron-sweet": {
+        "Name": "马卡龙甜心",
+        "Description": "柔和粉彩配色，轻松活泼"
+      },
+      "deep-ocean": {
+        "Name": "深海静谧",
+        "Description": "深海蓝绿色调，安静发光"
+      },
+      "vintage-press": {
+        "Name": "复古印刷",
+        "Description": "暖纸张色调，复古排印感"
+      }
+    }
   },
   "Layout": {
     "SearchTooltip": "搜索 (Ctrl+K)",

--- a/Monica.UI/Shell/Components/Layout/ThemeDialog.razor
+++ b/Monica.UI/Shell/Components/Layout/ThemeDialog.razor
@@ -86,7 +86,6 @@
 
     private void HandleThemeChanged()
     {
-        RefreshThemeOptions();
         InvokeAsync(StateHasChanged);
     }
 
@@ -98,7 +97,6 @@
     private void OnThemeChanged(string newTheme)
     {
         ThemeService.CurrentThemeName = newTheme;
-        RefreshThemeOptions();
         StateHasChanged();
     }
 

--- a/Monica.UI/Shell/Components/Layout/ThemeDialog.razor
+++ b/Monica.UI/Shell/Components/Layout/ThemeDialog.razor
@@ -1,6 +1,7 @@
 @using Microsoft.Extensions.Localization
 @using Monica.UI.Localization
 @using Monica.UI.Shell.State
+@using Monica.UI.Theming
 @inject ThemeState ThemeService
 @inject IStringLocalizer<SharedResource> L
 @implements IDisposable
@@ -20,7 +21,7 @@
                     <MudText Typo="Typo.subtitle1" Class="mb-3">@L["Theme:SelectStyle"]</MudText>
 
                     <MudStack Spacing="2">
-                        @foreach (var theme in ThemeState.AvailableThemes)
+                        @foreach (var theme in _themeOptions)
                         {
                             <MudCard Elevation="@(ThemeService.CurrentThemeName == theme.Name ? 4 : 1)"
                                      Class="@GetThemeCardClass(theme.Name)"
@@ -67,11 +68,14 @@
 </MudDialog>
 
 @code {
+    private IReadOnlyList<(string Name, string DisplayName, string Description)> _themeOptions = [];
+
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
 
     protected override void OnInitialized()
     {
+        RefreshThemeOptions();
         ThemeService.OnThemeChanged += HandleThemeChanged;
     }
 
@@ -82,6 +86,7 @@
 
     private void HandleThemeChanged()
     {
+        RefreshThemeOptions();
         InvokeAsync(StateHasChanged);
     }
 
@@ -93,14 +98,18 @@
     private void OnThemeChanged(string newTheme)
     {
         ThemeService.CurrentThemeName = newTheme;
+        RefreshThemeOptions();
         StateHasChanged();
     }
 
     private string GetCurrentThemeDisplayName()
     {
-        var current = ThemeState.AvailableThemes.FirstOrDefault(t => t.Name == ThemeService.CurrentThemeName);
-        var mode = ThemeService.IsDarkMode ? L["Theme:Dark"] : L["Theme:Light"];
-        return $"{current.DisplayName} - {mode}";
+        return ThemeDisplayTextProvider.GetCurrentThemeSummary(L, ThemeService.CurrentThemeName, ThemeService.IsDarkMode);
+    }
+
+    private void RefreshThemeOptions()
+    {
+        _themeOptions = ThemeDisplayTextProvider.GetThemeOptions(L);
     }
 
     private string GetThemeCardClass(string themeName)

--- a/Monica.UI/Shell/Components/Layout/ThemeSelector.razor
+++ b/Monica.UI/Shell/Components/Layout/ThemeSelector.razor
@@ -1,13 +1,16 @@
+@using Microsoft.Extensions.Localization
+@using Monica.UI.Localization
 @using Monica.UI.Shell.State
 @inject ThemeState ThemeService
 @inject IDialogService DialogService
+@inject IStringLocalizer<SharedResource> L
 
 <MudIconButton Icon="@Icons.Material.Filled.Palette"
                Color="Color.Primary"
                Size="Size.Medium"
                Class="action-button"
                OnClick="OpenThemeDialog"
-               title="主题设置" />
+               title="@L["Theme:Settings"]" />
 
 @code {
     private async Task OpenThemeDialog()
@@ -20,6 +23,6 @@
             CloseButton = true
         };
         
-        await DialogService.ShowAsync<ThemeDialog>("主题设置", options);
+        await DialogService.ShowAsync<ThemeDialog>(string.Empty, options);
     }
 }

--- a/Monica.UI/Theming/ThemeDisplayTextProvider.cs
+++ b/Monica.UI/Theming/ThemeDisplayTextProvider.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Microsoft.Extensions.Localization;
+using Monica.UI.Localization;
+
+namespace Monica.UI.Theming;
+
+public static class ThemeDisplayTextProvider
+{
+    public static IReadOnlyList<(string Name, string DisplayName, string Description)> GetThemeOptions(IStringLocalizer<SharedResource> localizer)
+    {
+        return ThemeCatalog.GetAvailableThemes()
+            .Select(theme =>
+            {
+                var displayName = GetLocalizedThemeValue(localizer, theme.Name, "Name", CreateNameFallback(theme.Name));
+                var description = GetLocalizedThemeValue(localizer, theme.Name, "Description", string.Empty);
+                return (theme.Name, displayName, description);
+            })
+            .ToArray();
+    }
+
+    public static string GetCurrentThemeSummary(IStringLocalizer<SharedResource> localizer, string themeName, bool isDarkMode)
+    {
+        var displayName = GetLocalizedThemeValue(localizer, themeName, "Name", CreateNameFallback(themeName));
+        var mode = isDarkMode ? localizer["Theme:Dark"] : localizer["Theme:Light"];
+        return $"{displayName} - {mode}";
+    }
+
+    private static string GetLocalizedThemeValue(IStringLocalizer<SharedResource> localizer, string themeName, string suffix, string fallback)
+    {
+        var key = $"Theme:Options:{themeName}:{suffix}";
+        var localized = localizer[key];
+        return localized.ResourceNotFound ? fallback : localized.Value;
+    }
+
+    private static string CreateNameFallback(string themeName)
+    {
+        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(themeName.Replace('-', ' '));
+    }
+}

--- a/tests/Test.Monica/Localization/EchoStringLocalizer.cs
+++ b/tests/Test.Monica/Localization/EchoStringLocalizer.cs
@@ -6,13 +6,13 @@ namespace Test.Monica.Localization;
 /// <summary>
 /// Returns localization keys as visible values so UI assertions stay deterministic.
 /// </summary>
-public sealed class EchoStringLocalizer<T> : IStringLocalizer<T>
+public class EchoStringLocalizer<T> : IStringLocalizer<T>
 {
     /// <inheritdoc />
-    public LocalizedString this[string name] => new(name, name, true);
+    public virtual LocalizedString this[string name] => new(name, name, true);
 
     /// <inheritdoc />
-    public LocalizedString this[string name, params object[] arguments]
+    public virtual LocalizedString this[string name, params object[] arguments]
         => new(name, $"{name} [{string.Join(", ", arguments.Select(static argument => argument?.ToString() ?? string.Empty))}]", true);
 
     /// <inheritdoc />

--- a/tests/Test.Monica/Test.Monica.csproj
+++ b/tests/Test.Monica/Test.Monica.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Test.Monica</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,5 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 </Project>

--- a/tests/Test.Monica/UI/ThemeDisplayTextProviderTests.cs
+++ b/tests/Test.Monica/UI/ThemeDisplayTextProviderTests.cs
@@ -1,0 +1,71 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Localization;
+using Monica.UI.Localization;
+using Monica.UI.Theming;
+using Test.Monica.Localization;
+using Xunit;
+
+namespace Test.Monica.UI;
+
+public class ThemeDisplayTextProviderTests
+{
+    private readonly IStringLocalizer<SharedResource> _localizer = new FoundStringLocalizer();
+
+    [Fact]
+    public void GetThemeOptions_ShouldReturnLocalizedNamesAndSimplifiedDescriptions()
+    {
+        var options = ThemeDisplayTextProvider.GetThemeOptions(_localizer);
+
+        options.Should().Contain(option => option.Name == "default" && option.DisplayName == "Theme:Options:default:Name" && option.Description == "Theme:Options:default:Description");
+        options.Should().Contain(option => option.Name == "aurora-flow" && option.DisplayName == "Theme:Options:aurora-flow:Name" && option.Description == "Theme:Options:aurora-flow:Description");
+    }
+
+    [Fact]
+    public void GetCurrentThemeSummary_ShouldUseLocalizedThemeNameAndMode()
+    {
+        var summary = ThemeDisplayTextProvider.GetCurrentThemeSummary(_localizer, "default", isDarkMode: true);
+
+        summary.Should().Be("Theme:Options:default:Name - Theme:Dark");
+    }
+
+    [Fact]
+    public void GetCurrentThemeSummary_ShouldFallbackToInvariantName_WhenLocalizationKeyMissing()
+    {
+        var localizer = new MissingThemeNameLocalizer();
+
+        var summary = ThemeDisplayTextProvider.GetCurrentThemeSummary(localizer, "deep-ocean", isDarkMode: false);
+
+        summary.Should().Be("Deep Ocean - Theme:Light");
+    }
+
+    [Fact]
+    public void GetThemeOptions_ShouldFallbackToEmptyDescription_WhenDescriptionKeyMissing()
+    {
+        var localizer = new MissingThemeDescriptionLocalizer();
+
+        var options = ThemeDisplayTextProvider.GetThemeOptions(localizer);
+
+        options.Should().Contain(option => option.Name == "default" && option.Description == string.Empty);
+    }
+
+    private class FoundStringLocalizer : EchoStringLocalizer<SharedResource>
+    {
+        public override LocalizedString this[string name] => new(name, name, resourceNotFound: false);
+    }
+
+    private sealed class MissingThemeNameLocalizer : FoundStringLocalizer
+    {
+        public override LocalizedString this[string name]
+            => name == "Theme:Options:deep-ocean:Name"
+                ? new LocalizedString(name, name, resourceNotFound: true)
+                : base[name];
+    }
+
+    private sealed class MissingThemeDescriptionLocalizer : FoundStringLocalizer
+    {
+        public override LocalizedString this[string name]
+            => name == "Theme:Options:default:Description"
+                ? new LocalizedString(name, name, resourceNotFound: true)
+                : base[name];
+    }
+}


### PR DESCRIPTION
## Summary
- remove the redundant outer MudBlazor dialog title from the theme settings dialog
- localize the theme selector tooltip and theme option display text
- add focused tests for theme display text fallback behavior

## Verification
- python .codex/skills/mo-ui-development/scripts/validate_localization.py
- dotnet test tests/Test.Monica/Test.Monica.csproj --no-restore
- dotnet build Monica.UI/Monica.UI.csproj --no-restore
- dotnet build Monica.Framework.UI/Monica.Framework.UI.csproj --no-restore
- Visual check via Monica.Docs bridge: /tmp/monica-theme-dialog-pr/theme-dialog.png

## Notes
- MudBlazor source check was attempted, but local source path is not configured; this fix does not depend on MudBlazor internals.
- An unrelated untracked file, examples/README.md, was left out of this PR.
