### PR TITLE
refactor: standardize remaining page routes to PAGE_URL

### DIFF
--- a/Monica.AI.UI/Pages/ChatPage.razor
+++ b/Monica.AI.UI/Pages/ChatPage.razor
@@ -1,4 +1,4 @@
-@page "/ai-chat"
+@attribute [Route(PAGE_URL)]
 @rendermode InteractiveServer
 @implements IDisposable
 

--- a/Monica.AI.UI/Pages/ProviderManagePage.razor
+++ b/Monica.AI.UI/Pages/ProviderManagePage.razor
@@ -1,4 +1,4 @@
-@page "/ai-providers"
+@attribute [Route(PAGE_URL)]
 @using Monica.Core.Results;
 @using Microsoft.Extensions.Localization
 @using Monica.AI.Facades

--- a/Monica.AI.UI/Pages/RAGChunkersPage.razor
+++ b/Monica.AI.UI/Pages/RAGChunkersPage.razor
@@ -1,4 +1,4 @@
-@page "/ai/rag/chunkers"
+@attribute [Route(PAGE_URL)]
 @using Microsoft.Extensions.Localization
 @using Monica.AI.UI.Localization
 @using Monica.AI.RAG.Facades

--- a/Monica.AI.UI/Pages/RAGDebugPage.razor
+++ b/Monica.AI.UI/Pages/RAGDebugPage.razor
@@ -1,4 +1,4 @@
-@page "/ai/rag/debug"
+@attribute [Route(PAGE_URL)]
 @rendermode InteractiveServer
 @using Monica.AI.RAG.Models
 @using Monica.AI.RAG.Facades

--- a/Monica.AI.UI/Pages/RAGManagePage.razor
+++ b/Monica.AI.UI/Pages/RAGManagePage.razor
@@ -1,4 +1,4 @@
-@page "/ai/rag/manage"
+@attribute [Route(PAGE_URL)]
 @implements IDisposable
 @using Microsoft.Extensions.Localization
 @using Monica.AI.UI.Localization

--- a/Monica.JobScheduler.UI/Pages/DashboardPage.razor
+++ b/Monica.JobScheduler.UI/Pages/DashboardPage.razor
@@ -1,4 +1,4 @@
-@page "/job-scheduler"
+@attribute [Route(PAGE_URL)]
 @page "/job-scheduler/dashboard"
 
 @using Monica.JobScheduler.UI.Components.Dashboard

--- a/Monica.JobScheduler.UI/Pages/DashboardPage.razor
+++ b/Monica.JobScheduler.UI/Pages/DashboardPage.razor
@@ -1,5 +1,5 @@
 @attribute [Route(PAGE_URL)]
-@page "/job-scheduler/dashboard"
+@attribute [Route(DASHBOARD_URL)]
 
 @using Monica.JobScheduler.UI.Components.Dashboard
 @using Monica.JobScheduler.UI.Localization
@@ -76,6 +76,7 @@
 
 @code {
     public const string PAGE_URL = "/job-scheduler";
+    public const string DASHBOARD_URL = "/job-scheduler/dashboard";
 
     private bool _isLoading = true;
     private bool _isRefreshing;

--- a/Monica.JobScheduler.UI/Pages/MonitorPage.razor
+++ b/Monica.JobScheduler.UI/Pages/MonitorPage.razor
@@ -1,4 +1,4 @@
-@page "/job-scheduler/monitor"
+@attribute [Route(PAGE_URL)]
 @using Monica.JobScheduler.UI.Components.Monitor
 @using Monica.JobScheduler.UI.Localization
 @using Monica.JobScheduler.UI.UIJobScheduler.Monitor.Models

--- a/Monica.JobScheduler.UI/Pages/StatisticsPage.razor
+++ b/Monica.JobScheduler.UI/Pages/StatisticsPage.razor
@@ -1,4 +1,4 @@
-@page "/job-scheduler/statistics"
+@attribute [Route(PAGE_URL)]
 
 @using Monica.JobScheduler.UI.Components.Statistics
 @using Monica.JobScheduler.UI.Localization


### PR DESCRIPTION
## Summary
- replace remaining single-route `@page` directives with `@attribute [Route(PAGE_URL)]` on AI and JobScheduler UI pages
- preserve the extra `/job-scheduler/dashboard` route while switching the primary job scheduler route to `PAGE_URL`
- keep the change scoped to PAGE_URL consistency only

## Verification
- `dotnet build Monica.slnx -m`
- updated bridge workflow verified ready at `http://localhost:5298`
- bridge screenshots captured for `/ai-chat`, `/job-scheduler/monitor`, and `/job-scheduler/statistics`
- Tailscale verification URL available at `http://100.114.135.51:5298`
