### PR TITLE
fix: refine job scheduler definition UI actions

### DIFF
--- a/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
+++ b/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
@@ -63,15 +63,15 @@
                 <MudGrid>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:InstanceId"]</MudText>
-                        <MudText Typo="Typo.body1" Style="font-family: monospace;">@_jobInstance.InstanceId</MudText>
+                        <MudText Typo="Typo.body1" Style="font-family: monospace; overflow-wrap: anywhere;" title="@_jobInstance.InstanceId">@_jobInstance.InstanceId</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:JobKey"]</MudText>
-                        <MudText Typo="Typo.body1">@_jobInstance.JobKey</MudText>
+                        <MudText Typo="Typo.body1" Style="overflow-wrap: anywhere;" title="@_jobInstance.JobKey">@_jobInstance.JobKey</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:RunningClient"]</MudText>
-                        <MudText Typo="Typo.body1" Style="font-family: monospace;">@(_jobInstance.RunningClientId ?? "-")</MudText>
+                        <MudText Typo="Typo.body1" Style="font-family: monospace; overflow-wrap: anywhere;" title="@_jobInstance.RunningClientId">@(_jobInstance.RunningClientId ?? "-")</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:State"]</MudText>
@@ -131,7 +131,7 @@
                                   Variant="Variant.Outlined"
                                   Lines="10"
                                   Sizing="InputSizing.Auto"
-                                  Style="font-family: monospace;" />
+                                  Style="font-family: monospace; overflow-x: auto;" />
                 </MudPaper>
             }
 

--- a/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
+++ b/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
@@ -1,3 +1,4 @@
+@using Microsoft.JSInterop
 @using System.Text.Encodings.Web
 @using System.Text.Json
 @using Monica.JobScheduler.UI.Localization
@@ -8,6 +9,7 @@
 @inject NavigationManager NavigationManager
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject IJSRuntime JSRuntime
 @inject IStringLocalizer<JobSchedulerResource> L
 
 <MudDialog>
@@ -63,7 +65,13 @@
                 <MudGrid>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:InstanceId"]</MudText>
-                        <MudText Typo="Typo.body1" Style="font-family: monospace; overflow-wrap: anywhere;" title="@_jobInstance.InstanceId">@_jobInstance.InstanceId</MudText>
+                        <MudTooltip Text="@_jobInstance.InstanceId">
+                            <MudLink Typo="Typo.body1"
+                                     Style="display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; cursor: pointer;"
+                                     OnClick="CopyInstanceIdAsync">
+                                @_jobInstance.InstanceId
+                            </MudLink>
+                        </MudTooltip>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:JobKey"]</MudText>
@@ -195,6 +203,17 @@
     {
         await LoadJobInstanceAsync();
         StateHasChanged();
+    }
+
+    private async Task CopyInstanceIdAsync()
+    {
+        if (_jobInstance == null)
+        {
+            return;
+        }
+
+        await JSRuntime.InvokeAsync<bool>("MoClipboard.copyText", _jobInstance.InstanceId);
+        Snackbar.Add(L["Dialogs:JobInstanceDetail:InstanceIdCopied"], Severity.Success);
     }
 
     private void NavigateToJobDefinition()

--- a/Monica.JobScheduler.UI/Localization/JobSchedulerResource/en-US.json
+++ b/Monica.JobScheduler.UI/Localization/JobSchedulerResource/en-US.json
@@ -140,7 +140,8 @@
       "PauseSuccess": "Job {0} paused",
       "PauseFailed": "Pause failed",
       "ResumeSuccess": "Job {0} resumed",
-      "ResumeFailed": "Resume failed"
+      "ResumeFailed": "Resume failed",
+      "JobKeyCopied": "Job key copied"
     }
   },
   "JobInstances": {
@@ -421,7 +422,8 @@
       "CancelConfirmTitle": "Confirm Cancel",
       "CancelConfirmMessage": "Are you sure you want to cancel job instance {0}?",
       "CancelSuccess": "Job cancelled",
-      "CancelFailed": "Cancel failed"
+      "CancelFailed": "Cancel failed",
+      "InstanceIdCopied": "Instance ID copied"
     },
     "JobExecute": {
       "Title": "Execute Job",

--- a/Monica.JobScheduler.UI/Localization/JobSchedulerResource/zh-CN.json
+++ b/Monica.JobScheduler.UI/Localization/JobSchedulerResource/zh-CN.json
@@ -140,7 +140,8 @@
       "PauseSuccess": "作业 {0} 已暂停",
       "PauseFailed": "暂停失败",
       "ResumeSuccess": "作业 {0} 已继续",
-      "ResumeFailed": "继续失败"
+      "ResumeFailed": "继续失败",
+      "JobKeyCopied": "作业键已复制"
     }
   },
   "JobInstances": {
@@ -421,7 +422,8 @@
       "CancelConfirmTitle": "确认取消",
       "CancelConfirmMessage": "确定要取消作业实例 {0} 吗？",
       "CancelSuccess": "作业已取消",
-      "CancelFailed": "取消失败"
+      "CancelFailed": "取消失败",
+      "InstanceIdCopied": "实例ID已复制"
     },
     "JobExecute": {
       "Title": "执行作业",

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionDetailPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionDetailPage.razor
@@ -25,7 +25,7 @@
     {
         <!-- Title and action buttons -->
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
-            <MudText Typo="Typo.h4">@_jobDefinition.JobName</MudText>
+            <MudText Typo="Typo.h4" Style="overflow-wrap: anywhere;" title="@_jobDefinition.JobName">@_jobDefinition.JobName</MudText>
             <MudStack Row="true" Spacing="2">
                 <MudButton Variant="Variant.Outlined"
                            Color="Color.Default"
@@ -78,7 +78,7 @@
             <MudGrid>
                 <MudItem xs="12" sm="6" md="3">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">@L["JobDetail:BasicInfo:JobKey"]</MudText>
-                    <MudText Typo="Typo.body1">@_jobDefinition.JobKey</MudText>
+                    <MudText Typo="Typo.body1" Style="overflow-wrap: anywhere;" title="@_jobDefinition.JobKey">@_jobDefinition.JobKey</MudText>
                 </MudItem>
                 <MudItem xs="12" sm="6" md="3">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">@L["JobDetail:BasicInfo:SourceProject"]</MudText>
@@ -308,8 +308,8 @@
                 {
                     <MudItem xs="12">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["JobDetail:BasicInfo:Description"]</MudText>
-                        <MudText Typo="Typo.body1">@_jobDefinition.Description</MudText>
-                    </MudItem>
+                    <MudText Typo="Typo.body1" Style="white-space: pre-wrap; overflow-wrap: anywhere;">@_jobDefinition.Description</MudText>
+                </MudItem>
                 }
             </MudGrid>
         </MudPaper>

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
@@ -6,7 +6,9 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject IBrowserStorage BrowserStorage
+@inject IJSRuntime JSRuntime
 @inject IStringLocalizer<JobSchedulerResource> L
+@using Microsoft.JSInterop
 @using Monica.JobScheduler.UI.Localization
 @using Monica.JobScheduler.UI.UIJobScheduler.Shared.Support
 
@@ -143,8 +145,8 @@
                     <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
                         <MudTooltip Text="@context.Definition.JobKey">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
-                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     OnClick="() => CopyJobKeyAsync(context.Definition.JobKey)">
                                 @context.Definition.JobKey
                             </MudLink>
                         </MudTooltip>
@@ -221,6 +223,12 @@
                                                Size="Size.Small"
                                                OnClick="() => ExecuteJobAsync(context.Definition.JobKey)" />
                             </MudTooltip>
+                            <MudTooltip Text="@L["JobDefinitions:Actions:ViewDetails"]">
+                                <MudIconButton Icon="@Icons.Material.Filled.Info"
+                                               Color="Color.Info"
+                                               Size="Size.Small"
+                                               OnClick="() => NavigateToDetail(context.Definition.JobKey)" />
+                            </MudTooltip>
                         </MudStack>
                     </MudTd>
                 </RowTemplate>
@@ -263,8 +271,8 @@
                     <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
                         <MudTooltip Text="@context.Definition.JobKey">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
-                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     OnClick="() => CopyJobKeyAsync(context.Definition.JobKey)">
                                 @context.Definition.JobKey
                             </MudLink>
                         </MudTooltip>
@@ -303,6 +311,12 @@
                                                Color="Color.Primary"
                                                Size="Size.Small"
                                                OnClick="() => ExecuteJobAsync(context.Definition.JobKey)" />
+                            </MudTooltip>
+                            <MudTooltip Text="@L["JobDefinitions:Actions:ViewDetails"]">
+                                <MudIconButton Icon="@Icons.Material.Filled.Info"
+                                               Color="Color.Info"
+                                               Size="Size.Small"
+                                               OnClick="() => NavigateToDetail(context.Definition.JobKey)" />
                             </MudTooltip>
                         </MudStack>
                     </MudTd>
@@ -629,6 +643,12 @@
                 await RefreshTriggerJobsAsync();
             }
         }
+    }
+
+    private async Task CopyJobKeyAsync(string jobKey)
+    {
+        await JSRuntime.InvokeAsync<bool>("MoClipboard.copyText", jobKey);
+        Snackbar.Add(L["JobDefinitions:Messages:JobKeyCopied"], Severity.Success);
     }
 
     private void NavigateToDetail(string jobKey)

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
@@ -140,8 +140,24 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="@L["JobDefinitions:Columns:SourceProject"]">@context.Definition.FromProject</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">@context.Definition.JobKey</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">@context.Definition.JobName</MudTd>
+                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
+                        <MudTooltip Text="@context.Definition.JobKey">
+                            <MudLink Typo="Typo.body2"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                @context.Definition.JobKey
+                            </MudLink>
+                        </MudTooltip>
+                    </MudTd>
+                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
+                        <MudTooltip Text="@context.Definition.JobName">
+                            <MudLink Typo="Typo.body2"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                @context.Definition.JobName
+                            </MudLink>
+                        </MudTooltip>
+                    </MudTd>
                     <MudTd DataLabel="@L["JobDefinitions:Columns:CronExpression"]">
                         <CronExpressionDisplay Expression="@context.Definition.CronExpression"
                                                DisplayMode="CronDisplayMode.Compact" />
@@ -199,11 +215,11 @@
                                                    OnClick="() => PauseJobAsync(context.Definition.JobKey)" />
                                 </MudTooltip>
                             }
-                            <MudTooltip Text="@L["JobDefinitions:Actions:ViewDetails"]">
-                                <MudIconButton Icon="@Icons.Material.Filled.Info"
-                                               Color="Color.Info"
+                            <MudTooltip Text="@L["JobDefinitions:Actions:Execute"]">
+                                <MudIconButton Icon="@Icons.Material.Filled.PlayCircle"
+                                               Color="Color.Primary"
                                                Size="Size.Small"
-                                               OnClick="() => NavigateToDetail(context.Definition.JobKey)" />
+                                               OnClick="() => ExecuteJobAsync(context.Definition.JobKey)" />
                             </MudTooltip>
                         </MudStack>
                     </MudTd>
@@ -244,8 +260,24 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="@L["JobDefinitions:Columns:SourceProject"]">@context.Definition.FromProject</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">@context.Definition.JobKey</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">@context.Definition.JobName</MudTd>
+                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
+                        <MudTooltip Text="@context.Definition.JobKey">
+                            <MudLink Typo="Typo.body2"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                @context.Definition.JobKey
+                            </MudLink>
+                        </MudTooltip>
+                    </MudTd>
+                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
+                        <MudTooltip Text="@context.Definition.JobName">
+                            <MudLink Typo="Typo.body2"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     OnClick="() => NavigateToDetail(context.Definition.JobKey)">
+                                @context.Definition.JobName
+                            </MudLink>
+                        </MudTooltip>
+                    </MudTd>
                     <MudTd DataLabel="@L["JobDefinitions:Columns:LastExecutionTime"]">
                         @if (context.LastExecution != null)
                         {
@@ -271,12 +303,6 @@
                                                Color="Color.Primary"
                                                Size="Size.Small"
                                                OnClick="() => ExecuteJobAsync(context.Definition.JobKey)" />
-                            </MudTooltip>
-                            <MudTooltip Text="@L["JobDefinitions:Actions:ViewDetails"]">
-                                <MudIconButton Icon="@Icons.Material.Filled.Info"
-                                               Color="Color.Info"
-                                               Size="Size.Small"
-                                               OnClick="() => NavigateToDetail(context.Definition.JobKey)" />
                             </MudTooltip>
                         </MudStack>
                     </MudTd>
@@ -591,10 +617,17 @@
         var dialog = await DialogService.ShowAsync<JobExecuteDialog>(L["Dialogs:JobExecute:Title"], parameters, options);
         var dialogResult = await dialog.Result;
 
-        // The execution results have been processed in the dialog box, refresh the list
+        // The execution results have been processed in the dialog box, refresh the active list.
         if (dialogResult is { Canceled: false })
         {
-            await RefreshTriggerJobsAsync();
+            if (_activeTabIndex == 0)
+            {
+                await RefreshRecurringJobsAsync();
+            }
+            else
+            {
+                await RefreshTriggerJobsAsync();
+            }
         }
     }
 

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
@@ -154,7 +154,7 @@
                     <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
                         <MudTooltip Text="@context.Definition.JobName">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
                                      OnClick="() => NavigateToDetail(context.Definition.JobKey)">
                                 @context.Definition.JobName
                             </MudLink>
@@ -280,7 +280,7 @@
                     <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
                         <MudTooltip Text="@context.Definition.JobName">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap;"
+                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
                                      OnClick="() => NavigateToDetail(context.Definition.JobKey)">
                                 @context.Definition.JobName
                             </MudLink>

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor.css
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor.css
@@ -12,10 +12,6 @@
     transform: translateY(0);
 }
 
-.font-monospace {
-    font-family: 'Courier New', Courier, monospace;
-}
-
 /* Batch operation toolbar animation */
 .batch-toolbar {
     animation: slideDown 0.2s ease-out;

--- a/Monica.JobScheduler/Models/JobInstance.cs
+++ b/Monica.JobScheduler/Models/JobInstance.cs
@@ -80,7 +80,7 @@ public class JobInstance
     /// <summary>
     /// Gets the state change history.
     /// Uses line-prefix format where each entry starts with ">>> " followed by metadata:
-    /// >>> [yyyy-MM-dd HH:mm:ss] [previous-state-label->newstate] optional message
+    /// >>> [yyyy-MM-dd HH:mm:ss.fff] [previous-state-label->newstate] optional message
     /// Multi-line messages (like stack traces) continue on following lines without the ">>> " prefix.
     /// </summary>
     public string? StateHistory { get; private set; }
@@ -196,7 +196,7 @@ public class JobInstance
     /// <param name="sourceClientId">Optional source client identifier that performed the state change.</param>
     internal void AppendStateHistory(string oldState, JobState newState, string? message, DateTime timestamp, string? sourceClientId = null)
     {
-        var header = $">>> [{timestamp:yyyy-MM-dd HH:mm:ss}] [{oldState}->{newState}]";
+        var header = $">>> [{timestamp:yyyy-MM-dd HH:mm:ss.fff}] [{oldState}->{newState}]";
         if (!string.IsNullOrWhiteSpace(sourceClientId))
         {
             header += $" [client:{sourceClientId}]";
@@ -337,7 +337,7 @@ public class JobInstance
         }
 
         var timestampStr = firstLine[1..timestampEnd];
-        if (!DateTime.TryParseExact(timestampStr, "yyyy-MM-dd HH:mm:ss",
+        if (!DateTime.TryParseExact(timestampStr, ["yyyy-MM-dd HH:mm:ss.fff", "yyyy-MM-dd HH:mm:ss"],
                 System.Globalization.CultureInfo.InvariantCulture,
                 System.Globalization.DateTimeStyles.None,
                 out var timestamp))


### PR DESCRIPTION
## Summary
- restore the job definition Details action while keeping quick Execute actions
- make job keys copy on click and keep job names navigating to definition detail
- improve long-field display in job definition and job instance detail views
- make job instance IDs show the full value in tooltip and copy on click
- preserve millisecond precision for job instance state history timestamps

## Test Plan
- [x] `dotnet build Monica.JobScheduler.UI/Monica.JobScheduler.UI.csproj -m`
- [x] Local Monica.Docs bridge/browser acceptance for job scheduler definitions UI

## Acceptance Notes
- Branch verified clean before PR creation.
- Local verification service was used at `http://127.0.0.1:5298/job-scheduler/definitions`.
- No PR was opened until after user acceptance.
