### PR TITLE
feat: localize observable instance UI

### DIFF
--- a/Monica.Framework.UI/Localization/ObservableInstanceLocalizationExtensions.cs
+++ b/Monica.Framework.UI/Localization/ObservableInstanceLocalizationExtensions.cs
@@ -37,7 +37,7 @@ public static class ObservableInstanceLocalizationExtensions
             LogLevel.Critical => localizer["Shared:LogLevels:Critical"].Value,
             LogLevel.None => localizer["Shared:LogLevels:None"].Value,
             null => localizer["Shared:LogLevels:Unknown"].Value,
-            _ => level.Value.ToString()
+            _ => localizer["Shared:LogLevels:Unknown"].Value
         };
     }
 
@@ -80,6 +80,10 @@ public static class ObservableInstanceLocalizationExtensions
     public static string FormatRelativeTime(this IStringLocalizer localizer, DateTime timestamp)
     {
         var elapsed = DateTime.UtcNow - timestamp;
+        if (elapsed < TimeSpan.Zero)
+        {
+            elapsed = TimeSpan.Zero;
+        }
 
         if (elapsed.TotalSeconds < 60)
             return localizer["Shared:RelativeTime:SecondsAgo", Math.Max(0, (int)elapsed.TotalSeconds)].Value;
@@ -106,21 +110,5 @@ public static class ObservableInstanceLocalizationExtensions
             return localizer["Shared:Duration:MinutesSeconds", (int)duration.TotalMinutes, duration.Seconds].Value;
 
         return localizer["Shared:Duration:Seconds", Math.Max(0, (int)duration.TotalSeconds)].Value;
-    }
-
-    /// <summary>
-    /// Gets localized group display text, preserving configured group identifiers.
-    /// </summary>
-    public static string GetGroupDisplayText(this IStringLocalizer localizer, ObservableInstanceViewModel instance)
-    {
-        return instance.HasGroup ? instance.GroupId! : localizer["Shared:Labels:Ungrouped"].Value;
-    }
-
-    /// <summary>
-    /// Gets localized type display text for nullable types.
-    /// </summary>
-    public static string GetNullableTypeDisplayText(this IStringLocalizer localizer, string value)
-    {
-        return value == "Unknown" ? localizer["Shared:Labels:Unknown"].Value : value;
     }
 }

--- a/Monica.Framework.UI/Localization/ObservableInstanceLocalizationExtensions.cs
+++ b/Monica.Framework.UI/Localization/ObservableInstanceLocalizationExtensions.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Monica.Framework.UI.UIObservableInstance.Models;
+
+namespace Monica.Framework.UI.Localization;
+
+/// <summary>
+/// Provides display text helpers for observable-instance UI localization.
+/// </summary>
+public static class ObservableInstanceLocalizationExtensions
+{
+    /// <summary>
+    /// Gets localized display text for a health state.
+    /// </summary>
+    public static string GetHealthStateText(this IStringLocalizer localizer, HealthState state)
+    {
+        return state switch
+        {
+            HealthState.Healthy => localizer["Shared:HealthStates:Healthy"].Value,
+            HealthState.Unhealthy => localizer["Shared:HealthStates:Unhealthy"].Value,
+            _ => localizer["Shared:HealthStates:Unknown"].Value
+        };
+    }
+
+    /// <summary>
+    /// Gets localized display text for a log level.
+    /// </summary>
+    public static string GetLogLevelText(this IStringLocalizer localizer, LogLevel? level)
+    {
+        return level switch
+        {
+            LogLevel.Trace => localizer["Shared:LogLevels:Trace"].Value,
+            LogLevel.Debug => localizer["Shared:LogLevels:Debug"].Value,
+            LogLevel.Information => localizer["Shared:LogLevels:Information"].Value,
+            LogLevel.Warning => localizer["Shared:LogLevels:Warning"].Value,
+            LogLevel.Error => localizer["Shared:LogLevels:Error"].Value,
+            LogLevel.Critical => localizer["Shared:LogLevels:Critical"].Value,
+            LogLevel.None => localizer["Shared:LogLevels:None"].Value,
+            null => localizer["Shared:LogLevels:Unknown"].Value,
+            _ => level.Value.ToString()
+        };
+    }
+
+
+    /// <summary>
+    /// Gets localized display text for an exception status.
+    /// </summary>
+    public static string GetExceptionStatusText(this IStringLocalizer localizer, bool hasExceptions, int exceptionCount)
+    {
+        return hasExceptions
+            ? localizer["Shared:ExceptionStatus:Count", exceptionCount].Value
+            : localizer["Shared:ExceptionStatus:Normal"].Value;
+    }
+
+    /// <summary>
+    /// Gets localized display text for an observable exception badge.
+    /// </summary>
+    public static string GetExceptionStatusText(this IStringLocalizer localizer, ObservableInstanceViewModel instance)
+    {
+        return localizer.GetExceptionStatusText(instance.HasExceptions, instance.ExceptionCount);
+    }
+
+    /// <summary>
+    /// Gets localized display text for a state-history entry type.
+    /// </summary>
+    public static string GetEntryTypeDescription(this IStringLocalizer localizer, ObservableStateHistoryViewModel entry)
+    {
+        return (entry.IsException, entry.IsStateTransition) switch
+        {
+            (true, true) => localizer["Shared:EntryTypes:StateChangeWithException"].Value,
+            (true, false) => localizer["Shared:EntryTypes:Exception"].Value,
+            (false, true) => localizer["Shared:EntryTypes:StateChange"].Value,
+            (false, false) => localizer["Shared:EntryTypes:Message"].Value
+        };
+    }
+
+    /// <summary>
+    /// Formats a relative timestamp with localized units.
+    /// </summary>
+    public static string FormatRelativeTime(this IStringLocalizer localizer, DateTime timestamp)
+    {
+        var elapsed = DateTime.UtcNow - timestamp;
+
+        if (elapsed.TotalSeconds < 60)
+            return localizer["Shared:RelativeTime:SecondsAgo", Math.Max(0, (int)elapsed.TotalSeconds)].Value;
+        if (elapsed.TotalMinutes < 60)
+            return localizer["Shared:RelativeTime:MinutesAgo", (int)elapsed.TotalMinutes].Value;
+        if (elapsed.TotalHours < 24)
+            return localizer["Shared:RelativeTime:HoursAgo", (int)elapsed.TotalHours].Value;
+        if (elapsed.TotalDays < 7)
+            return localizer["Shared:RelativeTime:DaysAgo", (int)elapsed.TotalDays].Value;
+
+        return timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff");
+    }
+
+    /// <summary>
+    /// Formats a duration with localized units.
+    /// </summary>
+    public static string FormatDuration(this IStringLocalizer localizer, TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1)
+            return localizer["Shared:Duration:DaysHours", (int)duration.TotalDays, duration.Hours].Value;
+        if (duration.TotalHours >= 1)
+            return localizer["Shared:Duration:HoursMinutes", (int)duration.TotalHours, duration.Minutes].Value;
+        if (duration.TotalMinutes >= 1)
+            return localizer["Shared:Duration:MinutesSeconds", (int)duration.TotalMinutes, duration.Seconds].Value;
+
+        return localizer["Shared:Duration:Seconds", Math.Max(0, (int)duration.TotalSeconds)].Value;
+    }
+
+    /// <summary>
+    /// Gets localized group display text, preserving configured group identifiers.
+    /// </summary>
+    public static string GetGroupDisplayText(this IStringLocalizer localizer, ObservableInstanceViewModel instance)
+    {
+        return instance.HasGroup ? instance.GroupId! : localizer["Shared:Labels:Ungrouped"].Value;
+    }
+
+    /// <summary>
+    /// Gets localized type display text for nullable types.
+    /// </summary>
+    public static string GetNullableTypeDisplayText(this IStringLocalizer localizer, string value)
+    {
+        return value == "Unknown" ? localizer["Shared:Labels:Unknown"].Value : value;
+    }
+}

--- a/Monica.Framework.UI/Localization/ObservableInstanceResource.cs
+++ b/Monica.Framework.UI/Localization/ObservableInstanceResource.cs
@@ -1,0 +1,11 @@
+using Monica.Core.Localization;
+using Monica.Core.Localization.Abstractions;
+
+namespace Monica.Framework.UI.Localization;
+
+/// <summary>
+/// Marker class for observable-instance UI localization resources.
+/// </summary>
+public class ObservableInstanceResource : ILocalizationResource
+{
+}

--- a/Monica.Framework.UI/Localization/ObservableInstanceResource/en-US.json
+++ b/Monica.Framework.UI/Localization/ObservableInstanceResource/en-US.json
@@ -1,0 +1,223 @@
+{
+  "Page": {
+    "PageTitle": "Observable Instance Monitor",
+    "Header": {
+      "Title": "Observable Instance Monitor"
+    },
+    "Tabs": {
+      "Overview": "Overview",
+      "AllInstances": "All Instances",
+      "ByGroup": "By Group",
+      "ExceptionsOnly": "Exceptions Only"
+    },
+    "RecentExceptions": {
+      "Title": "Recent Exceptions",
+      "Count": "{0} instances with exceptions"
+    },
+    "Group": {
+      "Count": "{0} instances",
+      "Empty": "No grouped instances"
+    },
+    "States": {
+      "LoadingInstances": "Loading instance information..."
+    },
+    "Messages": {
+      "LoadInstancesFailed": "Failed to load instances: {0}",
+      "LoadStatisticsFailed": "Failed to load statistics: {0}",
+      "LoadExceptionInstancesFailed": "Failed to load exception instances: {0}",
+      "LoadDataException": "An error occurred while loading data: {0}",
+      "RefreshSucceeded": "Data refreshed",
+      "ClearHistoryFailed": "Failed to clear history: {0}",
+      "ClearHistorySucceeded": "History cleared"
+    },
+    "Dialog": {
+      "DetailTitle": "Instance Details - {0}",
+      "ConfirmTitle": "Confirm",
+      "ClearHistoryMessage": "Clear history for instance '{0}'?",
+      "Confirm": "OK",
+      "Cancel": "Cancel"
+    }
+  },
+  "Shared": {
+    "Actions": {
+      "Refresh": "Refresh",
+      "ViewDetails": "View details",
+      "ClearHistory": "Clear history",
+      "Close": "Close",
+      "ClearFilters": "Clear filters",
+      "LoadMore": "Load more ({0} remaining)"
+    },
+    "Fields": {
+      "InstanceId": "Instance ID",
+      "Name": "Name",
+      "Type": "Type",
+      "Group": "Group",
+      "CurrentState": "Current State",
+      "HealthState": "Health State",
+      "LogLevel": "Log Level",
+      "Exceptions": "Exceptions",
+      "ExceptionCount": "Exception Count",
+      "RegisteredAt": "Registered At",
+      "LastUpdated": "Last Updated",
+      "Actions": "Actions",
+      "StateType": "State type",
+      "Message": "Message",
+      "StackTrace": "Stack Trace",
+      "Context": "Context Information",
+      "StateChange": "State Change",
+      "Previous": "Before",
+      "After": "After",
+      "ExceptionDetails": "Exception Details",
+      "ExceptionType": "Type",
+      "ExceptionMessage": "Message",
+      "ExceptionTime": "Time",
+      "InstanceKey": "Instance Key",
+      "CurrentLogLevel": "Current Log Level",
+      "NoLogLevel": "No log level",
+      "CurrentStateType": "Current State Type",
+      "StateChanges": "State Changes",
+      "HistoryEntries": "History Entries",
+      "ExceptionStatus": "Exception Status",
+      "StateHistory": "State History",
+      "ExceptionRecords": "Exception Records",
+      "InstanceName": "Instance Name",
+      "GroupId": "Group ID",
+      "OverallHealth": "Overall Health",
+      "StateValue": "State Value",
+      "StateChangedAt": "State Changed At",
+      "RunningDuration": "Running Duration",
+      "LogLevelDistribution": "Log Level Distribution",
+      "AverageHistory": "Average History",
+      "HealthRate": "Health Rate",
+      "HealthyInstanceRatio": "Ratio of instances without exceptions",
+      "TopTypeDistribution": "Top Type Distribution",
+      "TopGroupDistribution": "Top Group Distribution",
+      "PerInstance": "{0} entries/instance"
+    },
+    "Labels": {
+      "Unknown": "Unknown",
+      "Ungrouped": "Ungrouped",
+      "None": "None",
+      "RunningDuration": "Running {0}",
+      "LogLevel": "Log level: {0}",
+      "StateType": "Type: {0}"
+    },
+    "HealthStates": {
+      "Healthy": "Healthy",
+      "Unhealthy": "Unhealthy",
+      "Unknown": "Unknown"
+    },
+    "ExceptionStatus": {
+      "Normal": "Normal",
+      "Count": "{0} exceptions"
+    },
+    "EntryTypes": {
+      "StateChangeWithException": "State Change (Exception)",
+      "Exception": "Exception",
+      "StateChange": "State Change",
+      "Message": "Message"
+    },
+    "RelativeTime": {
+      "SecondsAgo": "{0} seconds ago",
+      "MinutesAgo": "{0} minutes ago",
+      "HoursAgo": "{0} hours ago",
+      "DaysAgo": "{0} days ago"
+    },
+    "Duration": {
+      "DaysHours": "{0} days {1} hours",
+      "HoursMinutes": "{0} hours {1} minutes",
+      "MinutesSeconds": "{0} minutes {1} seconds",
+      "Seconds": "{0} seconds"
+    },
+    "LogLevels": {
+      "Trace": "Trace",
+      "Debug": "Debug",
+      "Information": "Information",
+      "Warning": "Warning",
+      "Error": "Error",
+      "Critical": "Critical",
+      "None": "None",
+      "Unknown": "Unknown"
+    },
+    "States": {
+      "LoadingStatistics": "Loading statistics...",
+      "NoInstances": "No instance data",
+      "NoExceptions": "No exception records",
+      "NoStateHistory": "No state change records",
+      "NoInstanceSelected": "No instance selected"
+    },
+    "Counts": {
+      "ExceptionRecords": "{0} exception records"
+    }
+  },
+  "Statistics": {
+    "Title": "Instance Statistics",
+    "Cards": {
+      "TotalInstances": "Total Instances",
+      "HealthyInstances": "Healthy Instances",
+      "UnhealthyInstances": "Unhealthy Instances",
+      "UnknownHealth": "Unknown State",
+      "TotalStateChanges": "Total State Changes",
+      "TotalExceptions": "Total Exceptions",
+      "ExceptionRate": "Exception Rate",
+      "GroupedInstances": "Grouped Instances",
+      "AverageHistoryLength": "Average History Length",
+      "CriticalErrors": "Critical Errors"
+    },
+    "Sections": {
+      "LogLevelDistribution": "Log Level Distribution",
+      "AdditionalMetrics": "Additional Metrics",
+      "TopTypes": "Top Type Distribution",
+      "TopGroups": "Top Group Distribution"
+    }
+  },
+  "Filter": {
+    "Title": "Filter Conditions",
+    "ActiveCount": "{0} active",
+    "Fields": {
+      "Search": "Search",
+      "SearchPlaceholder": "Search by ID or name",
+      "Group": "Group",
+      "GroupPlaceholder": "Filter by group ID",
+      "HealthState": "Health State",
+      "LogLevel": "Log Level",
+      "RegisteredFrom": "Registered From",
+      "RegisteredTo": "Registered To"
+    },
+    "Options": {
+      "All": "All",
+      "AllHealthStates": "All health states",
+      "AllLogLevels": "All log levels",
+      "CriticalErrorOnly": "Critical/Error Only",
+      "UnhealthyOnly": "Unhealthy Only",
+      "QuickFilters": "Quick Filters:"
+    }
+  },
+  "Detail": {
+    "Title": "Instance Details",
+    "Sections": {
+      "BasicInfo": "Basic Information",
+      "StateInfo": "State Information",
+      "RuntimeStatistics": "Runtime Statistics",
+      "StateHistory": "State History",
+      "Exceptions": "Exceptions",
+      "Identity": "Identity Information",
+      "Health": "Health State",
+      "CurrentState": "Current State",
+      "Statistics": "Statistics"
+    },
+    "Actions": {
+      "LoadHistory": "Load History",
+      "LoadExceptions": "Load Exceptions"
+    },
+    "Messages": {
+      "LoadHistoryFailed": "Failed to load history: {0}",
+      "LoadExceptionsFailed": "Failed to load exceptions: {0}"
+    },
+    "Tabs": {
+      "Overview": "Overview",
+      "StateHistory": "State History",
+      "Exceptions": "Exceptions"
+    }
+  }
+}

--- a/Monica.Framework.UI/Localization/ObservableInstanceResource/zh-CN.json
+++ b/Monica.Framework.UI/Localization/ObservableInstanceResource/zh-CN.json
@@ -1,0 +1,223 @@
+{
+  "Page": {
+    "PageTitle": "可观测实例监控",
+    "Header": {
+      "Title": "可观测实例监控"
+    },
+    "Tabs": {
+      "Overview": "总览",
+      "AllInstances": "全部实例",
+      "ByGroup": "按组",
+      "ExceptionsOnly": "仅异常"
+    },
+    "RecentExceptions": {
+      "Title": "最近异常",
+      "Count": "{0} 个实例有异常"
+    },
+    "Group": {
+      "Count": "{0} 个实例",
+      "Empty": "暂无分组实例"
+    },
+    "States": {
+      "LoadingInstances": "正在加载实例信息..."
+    },
+    "Messages": {
+      "LoadInstancesFailed": "加载实例失败: {0}",
+      "LoadStatisticsFailed": "加载统计信息失败: {0}",
+      "LoadExceptionInstancesFailed": "加载异常实例失败: {0}",
+      "LoadDataException": "加载数据时发生错误: {0}",
+      "RefreshSucceeded": "数据已刷新",
+      "ClearHistoryFailed": "清除历史失败: {0}",
+      "ClearHistorySucceeded": "历史记录已清除"
+    },
+    "Dialog": {
+      "DetailTitle": "实例详情 - {0}",
+      "ConfirmTitle": "确认",
+      "ClearHistoryMessage": "确定要清除实例 '{0}' 的历史记录吗？",
+      "Confirm": "确定",
+      "Cancel": "取消"
+    }
+  },
+  "Shared": {
+    "Actions": {
+      "Refresh": "刷新",
+      "ViewDetails": "查看详情",
+      "ClearHistory": "清除历史",
+      "Close": "关闭",
+      "ClearFilters": "清除筛选",
+      "LoadMore": "加载更多 (剩余 {0} 条)"
+    },
+    "Fields": {
+      "InstanceId": "实例ID",
+      "Name": "名称",
+      "Type": "类型",
+      "Group": "组",
+      "CurrentState": "当前状态",
+      "HealthState": "健康状态",
+      "LogLevel": "日志级别",
+      "Exceptions": "异常",
+      "ExceptionCount": "异常数",
+      "RegisteredAt": "注册时间",
+      "LastUpdated": "最后更新",
+      "Actions": "操作",
+      "StateType": "状态类型",
+      "Message": "消息",
+      "StackTrace": "堆栈跟踪",
+      "Context": "上下文信息",
+      "StateChange": "状态变更",
+      "Previous": "之前",
+      "After": "之后",
+      "ExceptionDetails": "异常详情",
+      "ExceptionType": "类型",
+      "ExceptionMessage": "消息",
+      "ExceptionTime": "时间",
+      "InstanceKey": "实例键",
+      "CurrentLogLevel": "当前日志级别",
+      "NoLogLevel": "无日志级别",
+      "CurrentStateType": "当前状态类型",
+      "StateChanges": "状态变更",
+      "HistoryEntries": "历史记录",
+      "ExceptionStatus": "异常状态",
+      "StateHistory": "状态历史",
+      "ExceptionRecords": "异常记录",
+      "InstanceName": "实例名称",
+      "GroupId": "组ID",
+      "OverallHealth": "总体健康",
+      "StateValue": "状态值",
+      "StateChangedAt": "状态变更时间",
+      "RunningDuration": "运行时长",
+      "LogLevelDistribution": "日志级别分布",
+      "AverageHistory": "平均历史记录",
+      "HealthRate": "健康率",
+      "HealthyInstanceRatio": "无异常实例占比",
+      "TopTypeDistribution": "Top 类型分布",
+      "TopGroupDistribution": "Top 组分布",
+      "PerInstance": "{0} 条/实例"
+    },
+    "Labels": {
+      "Unknown": "未知",
+      "Ungrouped": "未分组",
+      "None": "无",
+      "RunningDuration": "运行 {0}",
+      "LogLevel": "日志级别: {0}",
+      "StateType": "类型: {0}"
+    },
+    "HealthStates": {
+      "Healthy": "健康",
+      "Unhealthy": "不健康",
+      "Unknown": "未知"
+    },
+    "ExceptionStatus": {
+      "Normal": "正常",
+      "Count": "{0} 异常"
+    },
+    "EntryTypes": {
+      "StateChangeWithException": "状态变更（异常）",
+      "Exception": "异常",
+      "StateChange": "状态变更",
+      "Message": "消息"
+    },
+    "RelativeTime": {
+      "SecondsAgo": "{0}秒前",
+      "MinutesAgo": "{0}分钟前",
+      "HoursAgo": "{0}小时前",
+      "DaysAgo": "{0}天前"
+    },
+    "Duration": {
+      "DaysHours": "{0}天 {1}小时",
+      "HoursMinutes": "{0}小时 {1}分钟",
+      "MinutesSeconds": "{0}分钟 {1}秒",
+      "Seconds": "{0}秒"
+    },
+    "LogLevels": {
+      "Trace": "Trace",
+      "Debug": "Debug",
+      "Information": "Information",
+      "Warning": "Warning",
+      "Error": "Error",
+      "Critical": "Critical",
+      "None": "None",
+      "Unknown": "未知"
+    },
+    "States": {
+      "LoadingStatistics": "加载统计信息...",
+      "NoInstances": "暂无实例数据",
+      "NoExceptions": "无异常记录",
+      "NoStateHistory": "暂无状态变更记录",
+      "NoInstanceSelected": "未选择实例"
+    },
+    "Counts": {
+      "ExceptionRecords": "共 {0} 个异常记录"
+    }
+  },
+  "Statistics": {
+    "Title": "实例统计",
+    "Cards": {
+      "TotalInstances": "总实例数",
+      "HealthyInstances": "健康实例",
+      "UnhealthyInstances": "不健康实例",
+      "UnknownHealth": "未知状态",
+      "TotalStateChanges": "总状态变更",
+      "TotalExceptions": "总异常数",
+      "ExceptionRate": "异常率",
+      "GroupedInstances": "分组实例",
+      "AverageHistoryLength": "平均历史长度",
+      "CriticalErrors": "严重错误"
+    },
+    "Sections": {
+      "LogLevelDistribution": "日志级别分布",
+      "AdditionalMetrics": "附加指标",
+      "TopTypes": "Top 类型分布",
+      "TopGroups": "Top 组分布"
+    }
+  },
+  "Filter": {
+    "Title": "筛选条件",
+    "ActiveCount": "{0} 个激活",
+    "Fields": {
+      "Search": "搜索",
+      "SearchPlaceholder": "搜索 ID 或名称",
+      "Group": "组",
+      "GroupPlaceholder": "按组 ID 筛选",
+      "HealthState": "健康状态",
+      "LogLevel": "日志级别",
+      "RegisteredFrom": "注册开始时间",
+      "RegisteredTo": "注册结束时间"
+    },
+    "Options": {
+      "All": "全部",
+      "AllHealthStates": "所有健康状态",
+      "AllLogLevels": "所有日志级别",
+      "CriticalErrorOnly": "仅严重/错误",
+      "UnhealthyOnly": "仅不健康",
+      "QuickFilters": "快速筛选:"
+    }
+  },
+  "Detail": {
+    "Title": "实例详情",
+    "Sections": {
+      "BasicInfo": "基本信息",
+      "StateInfo": "状态信息",
+      "RuntimeStatistics": "运行统计",
+      "StateHistory": "状态历史",
+      "Exceptions": "异常记录",
+      "Identity": "身份信息",
+      "Health": "健康状态",
+      "CurrentState": "当前状态",
+      "Statistics": "统计信息"
+    },
+    "Actions": {
+      "LoadHistory": "加载历史",
+      "LoadExceptions": "加载异常"
+    },
+    "Messages": {
+      "LoadHistoryFailed": "加载历史失败: {0}",
+      "LoadExceptionsFailed": "加载异常失败: {0}"
+    },
+    "Tabs": {
+      "Overview": "概览",
+      "StateHistory": "状态历史",
+      "Exceptions": "异常"
+    }
+  }
+}

--- a/Monica.Framework.UI/Modules/ModuleObservableInstanceUI.cs
+++ b/Monica.Framework.UI/Modules/ModuleObservableInstanceUI.cs
@@ -8,6 +8,7 @@ using Monica.Core.Modularity.Abstractions;
 using Monica.Core.Modularity.Annotations;
 using Monica.Core.Modularity.Models;
 using Monica.Core.Results;
+using Monica.Framework.UI.Localization;
 using Monica.Framework.UI.Pages;
 using Monica.Framework.UI.UIObservableInstance.Support;
 using MudBlazor;
@@ -51,6 +52,9 @@ public class ModuleObservableInstanceUI(ModuleObservableInstanceUIOption option)
         // Register UI page
         if (!Option.DisablePage)
         {
+            DependsOnModule<ModuleLocalizationGuide>().Register()
+                .AddResource<ObservableInstanceResource>();
+
             DependsOnModule<ModuleShellUIGuide>().Register()
                 .RegisterUIComponents(p => p.RegisterLocalizedComponent<UIObservableInstanceMonitorPage>(
                     UIObservableInstanceMonitorPage.PAGE_URL,

--- a/Monica.Framework.UI/Pages/UIObservableInstanceMonitorPage.razor
+++ b/Monica.Framework.UI/Pages/UIObservableInstanceMonitorPage.razor
@@ -2,12 +2,14 @@
 @using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.Framework.UI.UIObservableInstance.Components
 @using Monica.Core.Results;
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Support
 @inject ObservableInstanceMonitorService MonitorService
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject IStringLocalizer<ObservableInstanceResource> L
 
-<PageTitle>Observable Instance 监控</PageTitle>
+<PageTitle>@L["Page:PageTitle"]</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.False" Class="pa-4">
     <!-- Header -->
@@ -15,7 +17,7 @@
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
                 <MudIcon Icon="@Icons.Material.Filled.Inventory" Size="Size.Large" Color="Color.Primary" />
-                <MudText Typo="Typo.h4">Observable Instance 监控</MudText>
+                <MudText Typo="Typo.h4">@L["Page:Header:Title"]</MudText>
             </MudStack>
             <MudStack Row="true" Spacing="2">
                 <MudButton StartIcon="@Icons.Material.Filled.Refresh"
@@ -23,7 +25,7 @@
                           Variant="Variant.Outlined"
                           OnClick="RefreshAsync"
                           Size="Size.Medium">
-                    刷新
+                    @L["Shared:Actions:Refresh"]
                 </MudButton>
             </MudStack>
         </MudStack>
@@ -33,7 +35,7 @@
     {
         <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-8">
             <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-            <MudText Typo="Typo.h6" Color="Color.Primary">正在加载实例信息...</MudText>
+            <MudText Typo="Typo.h6" Color="Color.Primary">@L["Page:States:LoadingInstances"]</MudText>
         </MudStack>
     }
     else
@@ -41,7 +43,7 @@
         <!-- Tabs -->
         <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-4">
             <!-- Overview Tab -->
-            <MudTabPanel Text="总览" Icon="@Icons.Material.Filled.Dashboard">
+            <MudTabPanel Text="@L["Page:Tabs:Overview"]" Icon="@Icons.Material.Filled.Dashboard">
                 <ObservableInstanceStatisticsCard Statistics="_statistics" />
 
                 @if (_exceptionsPreview.Any())
@@ -51,10 +53,10 @@
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                     <MudIcon Icon="@Icons.Material.Filled.Error" Color="Color.Error" />
-                                    <MudText Typo="Typo.h6">最近异常</MudText>
+                                    <MudText Typo="Typo.h6">@L["Page:RecentExceptions:Title"]</MudText>
                                 </MudStack>
                                 <MudChip T="string" Color="Color.Error" Size="Size.Small">
-                                    @_exceptionsPreview.Count 个实例有异常
+                                    @L["Page:RecentExceptions:Count", _exceptionsPreview.Count]
                                 </MudChip>
                             </MudStack>
 
@@ -65,24 +67,24 @@
                                           Hover="true"
                                           OnRowClick="HandleExceptionPreviewRowClickAsync">
                                     <HeaderContent>
-                                        <MudTh Class="id-header">实例ID</MudTh>
-                                        <MudTh>名称</MudTh>
-                                        <MudTh>异常数</MudTh>
-                                        <MudTh>最后更新</MudTh>
+                                        <MudTh Class="id-header">@L["Shared:Fields:InstanceId"]</MudTh>
+                                        <MudTh>@L["Shared:Fields:Name"]</MudTh>
+                                        <MudTh>@L["Shared:Fields:ExceptionCount"]</MudTh>
+                                        <MudTh>@L["Shared:Fields:LastUpdated"]</MudTh>
                                     </HeaderContent>
                                     <RowTemplate>
-                                        <MudTd DataLabel="实例ID" Class="id-cell">
+                                        <MudTd DataLabel="@L["Shared:Fields:InstanceId"]" Class="id-cell">
                                             <MudTooltip Text="@context.InstanceId" RootClass="id-tooltip">
                                                 <span class="id-text">@context.InstanceId</span>
                                             </MudTooltip>
                                         </MudTd>
-                                        <MudTd DataLabel="名称">
+                                        <MudTd DataLabel="@L["Shared:Fields:Name"]">
                                             <span class="cell-text">@context.InstanceName</span>
                                         </MudTd>
                                         <MudTd>
                                             <MudChip T="string" Color="Color.Error" Size="Size.Small">@context.ExceptionCount</MudChip>
                                         </MudTd>
-                                        <MudTd DataLabel="最后更新">
+                                        <MudTd DataLabel="@L["Shared:Fields:LastUpdated"]">
                                             <span class="cell-text">@context.StateChangedAtDisplay</span>
                                         </MudTd>
                                     </RowTemplate>
@@ -94,7 +96,7 @@
             </MudTabPanel>
 
             <!-- All Instances Tab -->
-            <MudTabPanel Text="全部实例" Icon="@Icons.Material.Filled.List">
+            <MudTabPanel Text="@L["Page:Tabs:AllInstances"]" Icon="@Icons.Material.Filled.List">
                 <ObservableInstanceFilterPanel Filter="_filter" OnFilterChanged="ApplyFilterAsync" />
 
                 <ObservableInstanceTable Instances="_displayedInstances"
@@ -104,7 +106,7 @@
             </MudTabPanel>
 
             <!-- By Group Tab -->
-            <MudTabPanel Text="按组" Icon="@Icons.Material.Filled.Group">
+            <MudTabPanel Text="@L["Page:Tabs:ByGroup"]" Icon="@Icons.Material.Filled.Group">
                 @if (_instancesByGroup.Any())
                 {
                     <MudStack Spacing="3">
@@ -115,10 +117,10 @@
                                     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                             <MudIcon Icon="@Icons.Material.Filled.Group" Color="Color.Tertiary" />
-                                            <MudText Typo="Typo.h6">@groupPair.Key</MudText>
+                                            <MudText Typo="Typo.h6">@(string.IsNullOrEmpty(groupPair.Key) ? L["Shared:Labels:Ungrouped"] : groupPair.Key)</MudText>
                                         </MudStack>
                                         <MudChip T="string" Color="Color.Tertiary" Size="Size.Small">
-                                            @groupPair.Value.Count 个实例
+                                        @L["Page:Group:Count", groupPair.Value.Count]
                                         </MudChip>
                                     </MudStack>
                                     <ObservableInstanceTable Instances="groupPair.Value"
@@ -132,12 +134,12 @@
                 }
                 else
                 {
-                    <MudAlert Severity="Severity.Info">暂无分组实例</MudAlert>
+                    <MudAlert Severity="Severity.Info">@L["Page:Group:Empty"]</MudAlert>
                 }
             </MudTabPanel>
 
             <!-- Exceptions Only Tab -->
-            <MudTabPanel Text="仅异常" Icon="@Icons.Material.Filled.Error" BadgeData="@_exceptionsPreview.Count" BadgeColor="@(_exceptionsPreview.Any() ? Color.Error : Color.Default)">
+            <MudTabPanel Text="@L["Page:Tabs:ExceptionsOnly"]" Icon="@Icons.Material.Filled.Error" BadgeData="@_exceptionsPreview.Count" BadgeColor="@(_exceptionsPreview.Any() ? Color.Error : Color.Default)">
                 <ObservableInstanceTable Instances="_exceptionsPreview"
                                         Loading="_loading"
                                         OnRowClick="ShowInstanceDetail"
@@ -183,7 +185,7 @@
             // Load instances
             if ((await MonitorService.GetAllInstancesAsync()).IsFailed(out var error, out var instances))
             {
-                Snackbar.Add("加载实例列表失败: " + error, Severity.Error);
+                Snackbar.Add(L["Page:Messages:LoadInstancesFailed", error], Severity.Error);
             }
             else
             {
@@ -194,7 +196,7 @@
             // Load statistics
             if ((await MonitorService.GetStatisticsAsync()).IsFailed(out var statsError, out var stats))
             {
-                Snackbar.Add("加载统计信息失败: " + statsError, Severity.Error);
+                Snackbar.Add(L["Page:Messages:LoadStatisticsFailed", statsError], Severity.Error);
             }
             else
             {
@@ -204,7 +206,7 @@
             // Load exceptions preview
             if ((await MonitorService.GetInstancesWithExceptionsAsync()).IsFailed(out var excError, out var exceptions))
             {
-                Snackbar.Add("加载异常实例失败: " + excError, Severity.Error);
+                Snackbar.Add(L["Page:Messages:LoadExceptionInstancesFailed", excError], Severity.Error);
             }
             else
             {
@@ -216,7 +218,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"加载数据时发生错误: {ex.Message}", Severity.Error);
+            Snackbar.Add(L["Page:Messages:LoadDataException", ex.Message], Severity.Error);
         }
         finally
         {
@@ -228,7 +230,7 @@
     private async Task RefreshAsync()
     {
         await LoadDataAsync();
-        Snackbar.Add("数据已刷新", Severity.Success);
+        Snackbar.Add(L["Page:Messages:RefreshSucceeded"], Severity.Success);
     }
 
     private Task ApplyFilterAsync()
@@ -283,14 +285,14 @@
         // Group by GroupId
         _instancesByGroup = _allInstances
             .Where(i => i.HasGroup)
-            .GroupBy(i => i.GroupIdDisplay)
+            .GroupBy(i => i.GroupId ?? string.Empty)
             .ToDictionary(g => g.Key, g => g.ToList());
 
         // Add ungrouped instances as separate group
         var ungrouped = _allInstances.Where(i => !i.HasGroup).ToList();
         if (ungrouped.Any())
         {
-            _instancesByGroup["Ungrouped"] = ungrouped;
+            _instancesByGroup[string.Empty] = ungrouped;
         }
     }
 
@@ -314,25 +316,25 @@
             FullWidth = true
         };
 
-        await DialogService.ShowAsync<ObservableInstanceDetailDialog>($"实例详情 - {instance.InstanceName}", parameters, options);
+        await DialogService.ShowAsync<ObservableInstanceDetailDialog>(L["Page:Dialog:DetailTitle", instance.InstanceName], parameters, options);
     }
 
     private async Task ClearInstanceHistoryWithConfirmAsync(ObservableInstanceViewModel instance)
     {
         bool? result = await DialogService.ShowMessageBoxAsync(
-            "确认",
-            $"确定要清除实例 '{instance.InstanceName}' 的历史记录吗？",
-            yesText: "确定", cancelText: "取消");
+            L["Page:Dialog:ConfirmTitle"],
+            L["Page:Dialog:ClearHistoryMessage", instance.InstanceName],
+            yesText: L["Page:Dialog:Confirm"], cancelText: L["Page:Dialog:Cancel"]);
 
         if (result == true)
         {
             if ((await MonitorService.ClearInstanceHistoryAsync(instance.InstanceId)).IsFailed(out var error))
             {
-                Snackbar.Add("清除历史失败: " + error, Severity.Error);
+                Snackbar.Add(L["Page:Messages:ClearHistoryFailed", error], Severity.Error);
                 return;
             }
 
-            Snackbar.Add("历史记录已清除", Severity.Success);
+            Snackbar.Add(L["Page:Messages:ClearHistorySucceeded"], Severity.Success);
             await RefreshAsync();
         }
     }

--- a/Monica.Framework.UI/UIObservableInstance/Components/ExceptionList.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ExceptionList.razor
@@ -1,16 +1,18 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.UI.UIStackTrace.Components
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <div class="exception-list">
     @if (Exceptions == null || !Exceptions.Any())
     {
-        <MudAlert Severity="Severity.Success">无异常记录</MudAlert>
+        <MudAlert Severity="Severity.Success">@L["Shared:States:NoExceptions"]</MudAlert>
     }
     else
     {
         <MudStack Spacing="2">
         <MudText Typo="Typo.body1">
-            共 @Exceptions.Count 个异常记录
+            @L["Shared:Counts:ExceptionRecords", Exceptions.Count]
         </MudText>
 
         <MudStack Spacing="3">
@@ -28,7 +30,7 @@
                                     @exception.ExceptionMessage
                                 </MudText>
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    @exception.RelativeTimeDisplay
+                                    @L.FormatRelativeTime(exception.Timestamp)
                                 </MudText>
                             </MudStack>
                         </TitleContent>
@@ -37,19 +39,19 @@
                                 <MudStack Spacing="3">
                                     <!-- Exception Details -->
                                     <div>
-                                        <MudText Typo="Typo.subtitle2">异常详情</MudText>
+                                        <MudText Typo="Typo.subtitle2">@L["Shared:Fields:ExceptionDetails"]</MudText>
                                         <MudStack Spacing="2" Class="mt-2">
                                             <div>
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary">类型:</MudText>
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:ExceptionType"]:</MudText>
                                                 <MudText Typo="Typo.body2">@exception.ExceptionType</MudText>
                                             </div>
                                             <div>
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary">消息:</MudText>
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:ExceptionMessage"]:</MudText>
                                                 <MudText Typo="Typo.body2">@exception.ExceptionMessage</MudText>
                                             </div>
                                             <div>
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary">时间:</MudText>
-                                                <MudText Typo="Typo.body2">@exception.TimestampDisplay (@exception.RelativeTimeDisplay)</MudText>
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:ExceptionTime"]:</MudText>
+                                                <MudText Typo="Typo.body2">@exception.TimestampDisplay (@L.FormatRelativeTime(exception.Timestamp))</MudText>
                                             </div>
                                         </MudStack>
                                     </div>
@@ -58,7 +60,7 @@
                                     @if (!string.IsNullOrEmpty(exception.ExceptionStackTrace))
                                     {
                                         <div>
-                                            <MudText Typo="Typo.subtitle2" Class="mb-2">堆栈跟踪</MudText>
+                                            <MudText Typo="Typo.subtitle2" Class="mb-2">@L["Shared:Fields:StackTrace"]</MudText>
                                             <MudPaper Class="pa-3 scroll-panel-lg" Elevation="0" Outlined="true">
                                                 <StackTraceViewer Message="@exception.ExceptionStackTrace" />
                                             </MudPaper>
@@ -69,7 +71,7 @@
                                     @if (!string.IsNullOrEmpty(exception.Message))
                                     {
                                         <div>
-                                            <MudText Typo="Typo.caption" Color="Color.Secondary">上下文信息:</MudText>
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Context"]:</MudText>
                                             <MudText Typo="Typo.body2">@exception.Message</MudText>
                                         </div>
                                     }
@@ -78,15 +80,15 @@
                                     @if (exception.IsStateTransition)
                                     {
                                         <div>
-                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">状态变更:</MudText>
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">@L["Shared:Fields:StateChange"]:</MudText>
                                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                                 <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
-                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">之前:</MudText>
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Previous"]:</MudText>
                                                     <MudText Typo="Typo.caption">@exception.PreviousStateDisplay</MudText>
                                                 </MudPaper>
                                                 <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Small" />
                                                 <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
-                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">之后:</MudText>
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:After"]:</MudText>
                                                     <MudText Typo="Typo.caption">@exception.CurrentStateDisplay</MudText>
                                                 </MudPaper>
                                             </MudStack>

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceDetailPanel.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceDetailPanel.razor
@@ -1,46 +1,48 @@
-@using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.Core.Results;
+@using Monica.Framework.UI.Localization
+@using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.Framework.UI.UIObservableInstance.Support
 @inject ObservableInstanceMonitorService MonitorService
 @inject ISnackbar Snackbar
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <div class="detail-panel">
     @if (Instance == null)
     {
-        <MudAlert Severity="Severity.Info">未选择实例</MudAlert>
+        <MudAlert Severity="Severity.Info">@L["Shared:States:NoInstanceSelected"]</MudAlert>
     }
     else
     {
         <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
         <!-- Overview Tab -->
-        <MudTabPanel Text="概览" Icon="@Icons.Material.Filled.Dashboard">
+        <MudTabPanel Text="@L["Detail:Tabs:Overview"]" Icon="@Icons.Material.Filled.Dashboard">
             <MudStack Spacing="3" Class="pa-4">
                 <!-- Identity Information -->
                 <MudPaper Class="pa-3" Elevation="1">
-                    <MudText Typo="Typo.h6" Class="mb-3">身份信息</MudText>
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["Detail:Sections:Identity"]</MudText>
                     <MudGrid>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">实例ID</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:InstanceId"]</MudText>
                             <MudText Typo="Typo.body2" Class="break-anywhere">@Instance.InstanceId</MudText>
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">实例名称</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:InstanceName"]</MudText>
                             <MudText Typo="Typo.body2">@Instance.InstanceName</MudText>
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">类型</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Type"]</MudText>
                             <MudTooltip Text="@Instance.InstanceTypeFullName">
-                                <MudText Typo="Typo.body2">@Instance.InstanceTypeDisplay</MudText>
+                                <MudText Typo="Typo.body2">@L.GetNullableTypeDisplayText(Instance.InstanceTypeDisplay)</MudText>
                             </MudTooltip>
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">组ID</MudText>
-                            <MudText Typo="Typo.body2">@Instance.GroupIdDisplay</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:GroupId"]</MudText>
+                            <MudText Typo="Typo.body2">@L.GetGroupDisplayText(Instance)</MudText>
                         </MudItem>
                         @if (!string.IsNullOrEmpty(Instance.InstanceKey))
                         {
                             <MudItem xs="12">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">实例键</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:InstanceKey"]</MudText>
                                 <MudText Typo="Typo.body2">@Instance.InstanceKey</MudText>
                             </MudItem>
                         }
@@ -49,15 +51,15 @@
 
                 <!-- Health State -->
                 <MudPaper Class="pa-3" Elevation="1">
-                    <MudText Typo="Typo.h6" Class="mb-3">健康状态</MudText>
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["Detail:Sections:Health"]</MudText>
                     <MudStack Spacing="2">
                         <!-- Health State -->
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                            <MudText Typo="Typo.subtitle1" Class="detail-label">总体健康:</MudText>
+                            <MudText Typo="Typo.subtitle1" Class="detail-label">@L["Shared:Fields:OverallHealth"]:</MudText>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                 <MudIcon Icon="@Icons.Material.Filled.Circle" Size="Size.Small" Color="@Instance.HealthStateColor" />
                                 <MudChip T="string" Color="@Instance.HealthStateColor" Icon="@Instance.HealthStateIcon">
-                                    @Instance.HealthStateText
+                                    @L.GetHealthStateText(Instance.HealthState)
                                 </MudChip>
                             </MudStack>
                         </MudStack>
@@ -66,11 +68,11 @@
                         @if (Instance.CurrentLogLevel.HasValue)
                         {
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                                <MudText Typo="Typo.subtitle1" Class="detail-label">日志级别:</MudText>
+                                <MudText Typo="Typo.subtitle1" Class="detail-label">@L["Shared:Fields:LogLevel"]:</MudText>
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                     <MudIcon Icon="@Instance.LogLevelIcon" Size="Size.Small" Color="@Instance.LogLevelColor" />
                                     <MudChip T="string" Color="@Instance.LogLevelColor">
-                                        @Instance.LogLevelText
+                                        @L.GetLogLevelText(Instance.CurrentLogLevel)
                                     </MudChip>
                                 </MudStack>
                             </MudStack>
@@ -80,20 +82,20 @@
 
                 <!-- Current State -->
                 <MudPaper Class="pa-3" Elevation="1">
-                    <MudText Typo="Typo.h6" Class="mb-3">当前状态</MudText>
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["Detail:Sections:CurrentState"]</MudText>
                     <MudGrid>
                         <MudItem xs="12">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">状态值</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:StateValue"]</MudText>
                             <MudPaper Class="pa-2 mt-1" Elevation="0" Outlined="true">
                                 <MudText Typo="Typo.body2" Class="break-anywhere">@Instance.StateDisplayText</MudText>
                             </MudPaper>
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">状态类型</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:StateType"]</MudText>
                             <MudText Typo="Typo.body2">@Instance.StateTypeDisplay</MudText>
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">状态变更时间</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:StateChangedAt"]</MudText>
                             <MudText Typo="Typo.body2">@Instance.StateChangedAtDisplay</MudText>
                         </MudItem>
                     </MudGrid>
@@ -101,29 +103,29 @@
 
                 <!-- Statistics -->
                 <MudPaper Class="pa-3" Elevation="1">
-                    <MudText Typo="Typo.h6" Class="mb-3">统计信息</MudText>
+                    <MudText Typo="Typo.h6" Class="mb-3">@L["Detail:Sections:Statistics"]</MudText>
                     <MudGrid>
                         <MudItem xs="6" md="3">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">总状态变更</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:TotalStateChanges"]</MudText>
                             <MudText Typo="Typo.h6">@Instance.TotalStateChanges</MudText>
                         </MudItem>
                         <MudItem xs="6" md="3">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">总异常数</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:TotalExceptions"]</MudText>
                             <MudText Typo="Typo.h6" Color="@(Instance.TotalExceptions > 0 ? Color.Error : Color.Success)">
                                 @Instance.TotalExceptions
                             </MudText>
                         </MudItem>
                         <MudItem xs="6" md="3">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">历史记录数</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:HistoryEntries"]</MudText>
                             <MudText Typo="Typo.h6">@Instance.HistoryCount</MudText>
                         </MudItem>
                         <MudItem xs="6" md="3">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">注册时间</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:RegisteredAt"]</MudText>
                             <MudText Typo="Typo.body2">@Instance.RegisteredAtDisplay</MudText>
                         </MudItem>
                         <MudItem xs="12">
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">运行时长</MudText>
-                            <MudText Typo="Typo.body1">@Instance.RunningDurationDisplay</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:RunningDuration"]</MudText>
+                            <MudText Typo="Typo.body1">@L.FormatDuration(DateTime.UtcNow - Instance.RegisteredAt)</MudText>
                         </MudItem>
                     </MudGrid>
                 </MudPaper>
@@ -131,9 +133,9 @@
                 <!-- Status Badge -->
                 <MudPaper Class="pa-3" Elevation="1">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudText Typo="Typo.subtitle1">异常状态:</MudText>
+                        <MudText Typo="Typo.subtitle1">@L["Shared:Fields:ExceptionStatus"]:</MudText>
                         <MudChip T="string" Color="@Instance.ExceptionStatusColor" Icon="@(Instance.HasExceptions ? Icons.Material.Filled.Error : Icons.Material.Filled.CheckCircle)">
-                            @Instance.ExceptionStatusText
+                            @L.GetExceptionStatusText(Instance)
                         </MudChip>
                     </MudStack>
                 </MudPaper>
@@ -141,7 +143,7 @@
         </MudTabPanel>
 
         <!-- State History Tab -->
-        <MudTabPanel Text="状态历史" Icon="@Icons.Material.Filled.History">
+        <MudTabPanel Text="@L["Detail:Tabs:StateHistory"]" Icon="@Icons.Material.Filled.History">
             <MudStack Spacing="2" Class="pa-4">
                 @if (_loadingHistory)
                 {
@@ -155,7 +157,7 @@
         </MudTabPanel>
 
         <!-- Exceptions Tab -->
-        <MudTabPanel Text="异常" Icon="@Icons.Material.Filled.Error" BadgeData="@Instance.ExceptionCount" BadgeColor="@(Instance.HasExceptions ? Color.Error : Color.Default)">
+        <MudTabPanel Text="@L["Detail:Tabs:Exceptions"]" Icon="@Icons.Material.Filled.Error" BadgeData="@Instance.ExceptionCount" BadgeColor="@(Instance.HasExceptions ? Color.Error : Color.Default)">
             <MudStack Spacing="2" Class="pa-4">
                 @if (_loadingExceptions)
                 {
@@ -200,7 +202,7 @@
         {
             if ((await MonitorService.GetInstanceHistoryAsync(Instance.InstanceId, 100)).IsFailed(out var error, out var history))
             {
-                Snackbar.Add($"加载历史失败: {error}", Severity.Error);
+                Snackbar.Add(L["Detail:Messages:LoadHistoryFailed", error], Severity.Error);
                 return;
             }
 
@@ -224,7 +226,7 @@
         {
             if ((await MonitorService.GetInstanceExceptionsAsync(Instance.InstanceId)).IsFailed(out var error, out var exceptions))
             {
-                Snackbar.Add($"加载异常失败: {error}", Severity.Error);
+                Snackbar.Add(L["Detail:Messages:LoadExceptionsFailed", error], Severity.Error);
                 return;
             }
 

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceDetailPanel.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceDetailPanel.razor
@@ -32,12 +32,12 @@
                         <MudItem xs="12" md="6">
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Type"]</MudText>
                             <MudTooltip Text="@Instance.InstanceTypeFullName">
-                                <MudText Typo="Typo.body2">@L.GetNullableTypeDisplayText(Instance.InstanceTypeDisplay)</MudText>
+                                <MudText Typo="Typo.body2">@Instance.InstanceTypeDisplay</MudText>
                             </MudTooltip>
                         </MudItem>
                         <MudItem xs="12" md="6">
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:GroupId"]</MudText>
-                            <MudText Typo="Typo.body2">@L.GetGroupDisplayText(Instance)</MudText>
+                            <MudText Typo="Typo.body2">@Instance.GroupIdDisplay</MudText>
                         </MudItem>
                         @if (!string.IsNullOrEmpty(Instance.InstanceKey))
                         {

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceFilterPanel.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceFilterPanel.razor
@@ -1,4 +1,6 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <MudPaper Class="pa-4 mb-4" Elevation="2">
     <MudStack Spacing="3">
@@ -6,11 +8,11 @@
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                 <MudIcon Icon="@Icons.Material.Filled.FilterList" Color="Color.Primary" />
-                <MudText Typo="Typo.h6">筛选条件</MudText>
+                <MudText Typo="Typo.h6">@L["Filter:Title"]</MudText>
                 @if (Filter?.HasAnyFilter == true)
                 {
                     <MudChip T="string" Color="Color.Info" Size="Size.Small">
-                        @Filter.ActiveFilterCount 个筛选
+                        @L["Filter:ActiveCount", Filter.ActiveFilterCount]
                     </MudChip>
                 }
             </MudStack>
@@ -20,7 +22,7 @@
                           Size="Size.Small"
                           Color="Color.Default"
                           OnClick="ClearFilters">
-                    清除全部
+                    @L["Shared:Actions:ClearFilters"]
                 </MudButton>
             }
         </MudStack>
@@ -31,10 +33,10 @@
                 <!-- Search Text -->
                 <MudItem xs="12" md="6" lg="4">
                     <MudTextField T="string"
-                                 Label="搜索"
+                                 Label="@L["Filter:Fields:Search"]"
                                  @bind-Value="Filter.SearchText"
                                  Immediate="true"
-                                 Placeholder="输入实例ID或名称"
+                                 Placeholder="@L["Filter:Fields:SearchPlaceholder"]"
                                  Adornment="Adornment.Start"
                                  AdornmentIcon="@Icons.Material.Filled.Search"
                                  Clearable="true"
@@ -44,10 +46,10 @@
                 <!-- Group ID Filter -->
                 <MudItem xs="12" md="6" lg="4">
                     <MudTextField T="string"
-                                 Label="组ID"
+                                 Label="@L["Filter:Fields:Group"]"
                                  @bind-Value="Filter.GroupId"
                                  Immediate="true"
-                                 Placeholder="筛选指定组"
+                                 Placeholder="@L["Filter:Fields:GroupPlaceholder"]"
                                  Adornment="Adornment.Start"
                                  AdornmentIcon="@Icons.Material.Filled.Group"
                                  Clearable="true"
@@ -57,28 +59,28 @@
                 <!-- Health State Filter -->
                 <MudItem xs="12" md="6" lg="4">
                     <MudSelect T="HealthState?"
-                              Label="健康状态"
+                              Label="@L["Filter:Fields:HealthState"]"
                               @bind-Value="Filter.HealthStateFilter"
                               AnchorOrigin="Origin.BottomCenter"
                               Clearable="true"
                               OnClearButtonClick="OnFilterChanged">
-                        <MudSelectItem T="HealthState?" Value="@(null)">全部</MudSelectItem>
+                        <MudSelectItem T="HealthState?" Value="@(null)">@L["Filter:Options:All"]</MudSelectItem>
                         <MudSelectItem T="HealthState?" Value="@HealthState.Healthy">
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                 <MudIcon Icon="@Icons.Material.Filled.Circle" Size="Size.Small" Color="Color.Success" />
-                                <span>健康</span>
+                                <span>@L.GetHealthStateText(HealthState.Healthy)</span>
                             </MudStack>
                         </MudSelectItem>
                         <MudSelectItem T="HealthState?" Value="@HealthState.Unhealthy">
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                 <MudIcon Icon="@Icons.Material.Filled.Circle" Size="Size.Small" Color="Color.Error" />
-                                <span>不健康</span>
+                                <span>@L.GetHealthStateText(HealthState.Unhealthy)</span>
                             </MudStack>
                         </MudSelectItem>
                         <MudSelectItem T="HealthState?" Value="@HealthState.Unknown">
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                 <MudIcon Icon="@Icons.Material.Filled.Circle" Size="Size.Small" Color="Color.Default" />
-                                <span>未知</span>
+                                <span>@L.GetHealthStateText(HealthState.Unknown)</span>
                             </MudStack>
                         </MudSelectItem>
                     </MudSelect>
@@ -87,48 +89,42 @@
                 <!-- Log Level Filter -->
                 <MudItem xs="12" md="6" lg="4">
                     <MudSelect T="Microsoft.Extensions.Logging.LogLevel"
-                              Label="日志级别"
+                              Label="@L["Filter:Fields:LogLevel"]"
                               MultiSelection="true"
                               @bind-SelectedValues="_selectedLogLevels"
                               AnchorOrigin="Origin.BottomCenter"
                               Clearable="true"
                               OnClearButtonClick="HandleLogLevelClear">
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Critical">Critical</MudSelectItem>
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Error">Error</MudSelectItem>
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Warning">Warning</MudSelectItem>
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Information">Information</MudSelectItem>
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Debug">Debug</MudSelectItem>
-                        <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@Microsoft.Extensions.Logging.LogLevel.Trace">Trace</MudSelectItem>
+                        @foreach (var level in OrderedLogLevels)
+                        {
+                            <MudSelectItem T="Microsoft.Extensions.Logging.LogLevel" Value="@level">
+                                @L.GetLogLevelText(level)
+                            </MudSelectItem>
+                        }
                     </MudSelect>
                 </MudItem>
+
+                <!-- Quick Filters -->
+                <MudItem xs="12" md="6" lg="8">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="h-100">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Filter:Options:QuickFilters"]</MudText>
+                        <MudChip T="string"
+                                 Icon="@Icons.Material.Filled.Error"
+                                 Color="@(Filter?.ShowCriticalErrorOnly == true ? Color.Error : Color.Default)"
+                                 Variant="@(Filter?.ShowCriticalErrorOnly == true ? Variant.Filled : Variant.Outlined)"
+                                 OnClick="ToggleCriticalErrorFilter">
+                            @L["Filter:Options:CriticalErrorOnly"]
+                        </MudChip>
+                        <MudChip T="string"
+                                 Icon="@Icons.Material.Filled.Warning"
+                                 Color="@(Filter?.ShowUnhealthyOnly == true ? Color.Warning : Color.Default)"
+                                 Variant="@(Filter?.ShowUnhealthyOnly == true ? Variant.Filled : Variant.Outlined)"
+                                 OnClick="ToggleUnhealthyFilter">
+                            @L["Filter:Options:UnhealthyOnly"]
+                        </MudChip>
+                    </MudStack>
+                </MudItem>
             </MudGrid>
-
-            <!-- Quick Filters -->
-            <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
-                <MudText Typo="Typo.caption" Color="Color.Secondary">快速筛选:</MudText>
-                <MudChip T="string"
-                         Color="@(Filter?.ShowCriticalErrorOnly == true ? Color.Error : Color.Default)"
-                         Variant="@(Filter?.ShowCriticalErrorOnly == true ? Variant.Filled : Variant.Outlined)"
-                         OnClick="ToggleCriticalErrorFilter">
-                    仅显示 Critical/Error
-                </MudChip>
-                <MudChip T="string"
-                         Color="@(Filter?.ShowUnhealthyOnly == true ? Color.Warning : Color.Default)"
-                         Variant="@(Filter?.ShowUnhealthyOnly == true ? Variant.Filled : Variant.Outlined)"
-                         OnClick="ToggleUnhealthyFilter">
-                    仅显示不健康实例
-                </MudChip>
-            </MudStack>
-
-            <!-- Apply Button -->
-            <MudStack Row="true" Justify="Justify.FlexEnd">
-                <MudButton StartIcon="@Icons.Material.Filled.Done"
-                          Variant="Variant.Filled"
-                          Color="Color.Primary"
-                          OnClick="OnFilterChanged">
-                    应用筛选
-                </MudButton>
-            </MudStack>
         }
     </MudStack>
 </MudPaper>
@@ -147,27 +143,26 @@
         {
             if (Filter != null)
             {
-                Filter.LogLevels = value?.Any() == true ? value.ToHashSet() : null;
+                Filter.LogLevels = value?.ToHashSet();
+                _ = OnFilterChanged.InvokeAsync();
             }
         }
     }
 
+    private static Microsoft.Extensions.Logging.LogLevel[] OrderedLogLevels { get; } =
+    [
+        Microsoft.Extensions.Logging.LogLevel.Critical,
+        Microsoft.Extensions.Logging.LogLevel.Error,
+        Microsoft.Extensions.Logging.LogLevel.Warning,
+        Microsoft.Extensions.Logging.LogLevel.Information,
+        Microsoft.Extensions.Logging.LogLevel.Debug,
+        Microsoft.Extensions.Logging.LogLevel.Trace
+    ];
+
     private async Task ClearFilters()
     {
-        if (Filter != null)
-        {
-            Filter.Clear();
-            await OnFilterChanged.InvokeAsync();
-        }
-    }
-
-    private async Task HandleLogLevelClear()
-    {
-        if (Filter != null)
-        {
-            Filter.LogLevels = null;
-            await OnFilterChanged.InvokeAsync();
-        }
+        Filter?.Clear();
+        await OnFilterChanged.InvokeAsync();
     }
 
     private async Task ToggleCriticalErrorFilter()
@@ -184,6 +179,15 @@
         if (Filter != null)
         {
             Filter.ShowUnhealthyOnly = !Filter.ShowUnhealthyOnly;
+            await OnFilterChanged.InvokeAsync();
+        }
+    }
+
+    private async Task HandleLogLevelClear()
+    {
+        if (Filter != null)
+        {
+            Filter.LogLevels = null;
             await OnFilterChanged.InvokeAsync();
         }
     }

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceFilterPanel.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceFilterPanel.razor
@@ -91,7 +91,8 @@
                     <MudSelect T="Microsoft.Extensions.Logging.LogLevel"
                               Label="@L["Filter:Fields:LogLevel"]"
                               MultiSelection="true"
-                              @bind-SelectedValues="_selectedLogLevels"
+                              SelectedValues="@SelectedLogLevels"
+                              SelectedValuesChanged="HandleLogLevelsChanged"
                               AnchorOrigin="Origin.BottomCenter"
                               Clearable="true"
                               OnClearButtonClick="HandleLogLevelClear">
@@ -136,18 +137,8 @@
     [Parameter]
     public EventCallback OnFilterChanged { get; set; }
 
-    private IReadOnlyCollection<Microsoft.Extensions.Logging.LogLevel> _selectedLogLevels
-    {
-        get => Filter?.LogLevels?.ToList() ?? (IReadOnlyCollection<Microsoft.Extensions.Logging.LogLevel>)Array.Empty<Microsoft.Extensions.Logging.LogLevel>();
-        set
-        {
-            if (Filter != null)
-            {
-                Filter.LogLevels = value?.ToHashSet();
-                _ = OnFilterChanged.InvokeAsync();
-            }
-        }
-    }
+    private IReadOnlyCollection<Microsoft.Extensions.Logging.LogLevel> SelectedLogLevels =>
+        Filter?.LogLevels?.ToArray() ?? Array.Empty<Microsoft.Extensions.Logging.LogLevel>();
 
     private static Microsoft.Extensions.Logging.LogLevel[] OrderedLogLevels { get; } =
     [
@@ -188,6 +179,15 @@
         if (Filter != null)
         {
             Filter.LogLevels = null;
+            await OnFilterChanged.InvokeAsync();
+        }
+    }
+
+    private async Task HandleLogLevelsChanged(IEnumerable<Microsoft.Extensions.Logging.LogLevel>? values)
+    {
+        if (Filter != null)
+        {
+            Filter.LogLevels = values?.ToHashSet();
             await OnFilterChanged.InvokeAsync();
         }
     }

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceStatisticsCard.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceStatisticsCard.razor
@@ -1,12 +1,14 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.Framework.UI.UIObservableInstance.Support
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <MudPaper Class="pa-4 mb-4" Elevation="2">
     @if (Statistics == null)
     {
         <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="pa-4">
             <MudProgressCircular Color="Color.Info" Indeterminate="true" />
-            <MudText Typo="Typo.body2" Color="Color.Secondary">加载统计信息...</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["Shared:States:LoadingStatistics"]</MudText>
         </MudStack>
     }
     else
@@ -15,7 +17,7 @@
             <!-- Title -->
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                 <MudIcon Icon="@Icons.Material.Filled.Dashboard" Color="Color.Info" />
-                <MudText Typo="Typo.h6">实例统计</MudText>
+                <MudText Typo="Typo.h6">@L["Statistics:Title"]</MudText>
             </MudStack>
 
             <!-- Statistics Cards Grid -->
@@ -25,7 +27,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">总实例数</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:TotalInstances"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.Inventory" Color="Color.Primary" />
                             </MudStack>
                             <MudText Typo="Typo.h4">@Statistics.TotalInstances</MudText>
@@ -38,7 +40,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">健康实例</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:HealthyInstances"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" />
                             </MudStack>
                             <MudText Typo="Typo.h4" Color="Color.Success">@Statistics.HealthyCount</MudText>
@@ -51,7 +53,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">不健康实例</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:UnhealthyInstances"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Error" />
                             </MudStack>
                             <MudText Typo="Typo.h4" Color="Color.Error">@Statistics.UnhealthyCount</MudText>
@@ -64,7 +66,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">未知状态</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:UnknownHealth"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.HelpOutline" Color="Color.Default" />
                             </MudStack>
                             <MudText Typo="Typo.h4">@Statistics.UnknownHealthCount</MudText>
@@ -77,7 +79,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">总状态变更</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:TotalStateChanges"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Color="Color.Info" />
                             </MudStack>
                             <MudText Typo="Typo.h4">@Statistics.TotalStateChanges</MudText>
@@ -90,7 +92,7 @@
                     <MudPaper Class="pa-3" Elevation="1" Outlined="true">
                         <MudStack Spacing="1">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">总异常数</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Statistics:Cards:TotalExceptions"]</MudText>
                                 <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Color="Color.Warning" />
                             </MudStack>
                             <MudText Typo="Typo.h4" Color="@(Statistics.TotalExceptions > 0 ? Color.Warning : Color.Default)">@Statistics.TotalExceptions</MudText>
@@ -104,14 +106,14 @@
             {
                 <MudPaper Class="pa-3" Elevation="1">
                     <MudStack Spacing="2">
-                        <MudText Typo="Typo.subtitle1">日志级别分布</MudText>
-                        <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
-                            @foreach (var logLevel in Statistics.LogLevelDistribution.OrderBy(kv => kv.Key))
+                        <MudText Typo="Typo.subtitle1">@L["Statistics:Sections:LogLevelDistribution"]</MudText>
+                        <MudStack Row="true" Spacing="2" Style="flex-wrap: wrap;">
+                            @foreach (var logLevel in Statistics.LogLevelDistribution.OrderByDescending(kvp => kvp.Key))
                             {
                                 var color = ObservableInstanceDisplayMapping.GetLogLevelColor(logLevel.Key);
                                 var icon = ObservableInstanceDisplayMapping.GetLogLevelIcon(logLevel.Key);
                                 <MudChip T="string" Color="@color" Icon="@icon">
-                                    @logLevel.Key: @logLevel.Value
+                                    @L.GetLogLevelText(logLevel.Key): @logLevel.Value
                                 </MudChip>
                             }
                         </MudStack>
@@ -124,8 +126,8 @@
                 <MudItem xs="12" md="6">
                     <MudPaper Class="pa-3" Elevation="1">
                         <MudStack Spacing="2">
-                            <MudText Typo="Typo.subtitle1">平均历史记录</MudText>
-                            <MudText Typo="Typo.h5">@Statistics.AverageHistoryPerInstance.ToString("F2") 条/实例</MudText>
+                            <MudText Typo="Typo.subtitle1">@L["Shared:Fields:AverageHistory"]</MudText>
+                            <MudText Typo="Typo.h5">@L["Shared:Fields:PerInstance", Statistics.AverageHistoryPerInstance.ToString("F2")]</MudText>
                         </MudStack>
                     </MudPaper>
                 </MudItem>
@@ -133,10 +135,10 @@
                 <MudItem xs="12" md="6">
                     <MudPaper Class="pa-3" Elevation="1">
                         <MudStack Spacing="2">
-                            <MudText Typo="Typo.subtitle1">健康率</MudText>
+                            <MudText Typo="Typo.subtitle1">@L["Shared:Fields:HealthRate"]</MudText>
                             <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
                                 <MudText Typo="Typo.h5">@GetHealthPercentage()%</MudText>
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">无异常实例占比</MudText>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["Shared:Fields:HealthyInstanceRatio"]</MudText>
                             </MudStack>
                         </MudStack>
                     </MudPaper>
@@ -152,7 +154,7 @@
                         <MudItem xs="12" md="6">
                             <MudPaper Class="pa-3" Elevation="1">
                                 <MudStack Spacing="2">
-                                    <MudText Typo="Typo.subtitle1">Top 类型分布</MudText>
+                                    <MudText Typo="Typo.subtitle1">@L["Shared:Fields:TopTypeDistribution"]</MudText>
                                     <MudList T="string" Dense="true">
                                         @foreach (var typeCount in Statistics.TopTypesByCount.Take(5))
                                         {
@@ -176,13 +178,13 @@
                         <MudItem xs="12" md="6">
                             <MudPaper Class="pa-3" Elevation="1">
                                 <MudStack Spacing="2">
-                                    <MudText Typo="Typo.subtitle1">Top 组分布</MudText>
+                                    <MudText Typo="Typo.subtitle1">@L["Shared:Fields:TopGroupDistribution"]</MudText>
                                     <MudList T="string" Dense="true">
                                         @foreach (var groupCount in Statistics.TopGroupsByCount.Take(5))
                                         {
                                             <MudListItem T="string">
                                                 <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                                                    <MudText Typo="Typo.body2">@groupCount.GroupId</MudText>
+                                                    <MudText Typo="Typo.body2">@(string.IsNullOrEmpty(groupCount.GroupId) ? L["Shared:Labels:Ungrouped"] : groupCount.GroupId)</MudText>
                                                     <MudChip T="string" Size="Size.Small" Color="Color.Tertiary">@groupCount.Count</MudChip>
                                                 </MudStack>
                                             </MudListItem>

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceTable.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceTable.razor
@@ -1,4 +1,6 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <div class="instance-table @(Compact ? "compact" : null)">
     <MudTable T="ObservableInstanceViewModel"
@@ -10,77 +12,77 @@
              LoadingProgressColor="Color.Info"
              RowsPerPage="@(Compact ? 10 : 20)">
         <HeaderContent>
-            <MudTh Class="id-header">实例ID</MudTh>
-            <MudTh>实例名称</MudTh>
-            <MudTh>类型</MudTh>
-            <MudTh>组</MudTh>
-            <MudTh>当前状态</MudTh>
-            <MudTh>健康状态</MudTh>
-            <MudTh>日志级别</MudTh>
-            <MudTh>异常</MudTh>
-            <MudTh>注册时间</MudTh>
+            <MudTh Class="id-header">@L["Shared:Fields:InstanceId"]</MudTh>
+            <MudTh>@L["Shared:Fields:Name"]</MudTh>
+            <MudTh>@L["Shared:Fields:Type"]</MudTh>
+            <MudTh>@L["Shared:Fields:Group"]</MudTh>
+            <MudTh>@L["Shared:Fields:CurrentState"]</MudTh>
+            <MudTh>@L["Shared:Fields:HealthState"]</MudTh>
+            <MudTh>@L["Shared:Fields:LogLevel"]</MudTh>
+            <MudTh>@L["Shared:Fields:Exceptions"]</MudTh>
+            <MudTh>@L["Shared:Fields:RegisteredAt"]</MudTh>
             @if (!Compact)
             {
-                <MudTh>操作</MudTh>
+                <MudTh>@L["Shared:Fields:Actions"]</MudTh>
             }
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="实例ID" Class="id-cell">
+            <MudTd DataLabel="@L["Shared:Fields:InstanceId"]" Class="id-cell">
                 <MudTooltip Text="@context.InstanceId" RootClass="id-tooltip">
                     <span class="id-text" @onclick="() => OnRowClick.InvokeAsync(context)">
                         @context.InstanceId
                     </span>
                 </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="实例名称">
+            <MudTd DataLabel="@L["Shared:Fields:Name"]">
                 <span class="cell-text">@context.InstanceName</span>
             </MudTd>
-            <MudTd DataLabel="类型">
+            <MudTd DataLabel="@L["Shared:Fields:Type"]">
                 <MudTooltip Text="@context.InstanceTypeFullName" RootClass="cell-tooltip">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="type-cell">
                         <MudIcon Icon="@Icons.Material.Filled.Category" Size="Size.Small" Color="Color.Default" />
-                        <span class="cell-text">@context.InstanceTypeDisplay</span>
+                        <span class="cell-text">@L.GetNullableTypeDisplayText(context.InstanceTypeDisplay)</span>
                     </MudStack>
                 </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="组">
+            <MudTd DataLabel="@L["Shared:Fields:Group"]">
                 @if (context.HasGroup)
                 {
-                    <MudTooltip Text="@context.GroupIdDisplay" RootClass="cell-tooltip">
+                    <MudTooltip Text="@context.GroupId" RootClass="cell-tooltip">
                         <MudChip T="string" Color="Color.Tertiary" Size="Size.Small">
-                            @context.GroupIdDisplay
+                            @L.GetGroupDisplayText(context)
                         </MudChip>
                     </MudTooltip>
                 }
                 else
                 {
                     <MudText Typo="Typo.body2" Color="Color.Secondary" Class="cell-text">
-                        @context.GroupIdDisplay
+                        @L.GetGroupDisplayText(context)
                     </MudText>
                 }
             </MudTd>
-            <MudTd DataLabel="当前状态">
-                <MudTooltip Text="@($"类型: {context.StateTypeDisplay}")" RootClass="cell-tooltip">
+            <MudTd DataLabel="@L["Shared:Fields:CurrentState"]">
+                <MudTooltip Text="@L["Shared:Labels:StateType", context.StateTypeDisplay]" RootClass="cell-tooltip">
                     <span class="cell-text">
                         @context.StateDisplayText
                     </span>
                 </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="健康状态">
+            <MudTd DataLabel="@L["Shared:Fields:HealthState"]">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                     <MudIcon Icon="@Icons.Material.Filled.Circle" Size="Size.Small" Color="@context.HealthStateColor" />
                     <MudText Typo="Typo.body2" Color="@context.HealthStateColor">
-                        @context.HealthStateText
+                        @L.GetHealthStateText(context.HealthState)
                     </MudText>
                 </MudStack>
             </MudTd>
-            <MudTd DataLabel="日志级别">
+            <MudTd DataLabel="@L["Shared:Fields:LogLevel"]">
                 @if (context.CurrentLogLevel.HasValue)
                 {
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                         <MudIcon Icon="@context.LogLevelIcon" Size="Size.Small" Color="@context.LogLevelColor" />
                         <MudText Typo="Typo.body2" Color="@context.LogLevelColor" Class="cell-text">
-                            @context.LogLevelText
+                            @L.GetLogLevelText(context.CurrentLogLevel)
                         </MudText>
                     </MudStack>
                 }
@@ -89,34 +91,34 @@
                     <MudText Typo="Typo.body2" Color="Color.Secondary" Class="cell-text">-</MudText>
                 }
             </MudTd>
-            <MudTd DataLabel="异常">
+            <MudTd DataLabel="@L["Shared:Fields:Exceptions"]">
                 <MudChip T="string" Color="@context.ExceptionStatusColor" Size="Size.Small" Icon="@(context.HasExceptions ? Icons.Material.Filled.Error : Icons.Material.Filled.CheckCircle)">
-                    @context.ExceptionStatusText
+                    @L.GetExceptionStatusText(context)
                 </MudChip>
             </MudTd>
-            <MudTd DataLabel="注册时间">
+            <MudTd DataLabel="@L["Shared:Fields:RegisteredAt"]">
                 <MudStack Spacing="0">
                     <span class="cell-text">@context.RegisteredAtDisplay</span>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                        运行 @context.RunningDurationDisplay
+                        @L["Shared:Labels:RunningDuration", L.FormatDuration(DateTime.UtcNow - context.RegisteredAt)]
                     </MudText>
                 </MudStack>
             </MudTd>
             @if (!Compact)
             {
-                <MudTd DataLabel="操作">
+                <MudTd DataLabel="@L["Shared:Fields:Actions"]">
                     <MudIconButton Icon="@Icons.Material.Filled.Visibility"
                                   Size="Size.Small"
                                   Color="Color.Info"
                                   OnClick="() => OnRowClick.InvokeAsync(context)"
-                                  title="查看详情"
-                                  aria-label="查看详情" />
+                                  title="@L["Shared:Actions:ViewDetails"]"
+                                  aria-label="@L["Shared:Actions:ViewDetails"]" />
                     <MudIconButton Icon="@Icons.Material.Filled.DeleteSweep"
                                   Size="Size.Small"
                                   Color="Color.Warning"
                                   OnClick="() => OnClearHistory.InvokeAsync(context)"
-                                  title="清除历史"
-                                  aria-label="清除历史" />
+                                  title="@L["Shared:Actions:ClearHistory"]"
+                                  aria-label="@L["Shared:Actions:ClearHistory"]" />
                 </MudTd>
             }
         </RowTemplate>
@@ -126,7 +128,7 @@
         <NoRecordsContent>
             <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="pa-4">
                 <MudIcon Icon="@Icons.Material.Filled.Inventory" Size="Size.Large" Color="Color.Secondary" />
-                <MudText Typo="Typo.body1" Color="Color.Secondary">暂无实例数据</MudText>
+                <MudText Typo="Typo.body1" Color="Color.Secondary">@L["Shared:States:NoInstances"]</MudText>
             </MudStack>
         </NoRecordsContent>
     </MudTable>

--- a/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceTable.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/ObservableInstanceTable.razor
@@ -41,7 +41,7 @@
                 <MudTooltip Text="@context.InstanceTypeFullName" RootClass="cell-tooltip">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="type-cell">
                         <MudIcon Icon="@Icons.Material.Filled.Category" Size="Size.Small" Color="Color.Default" />
-                        <span class="cell-text">@L.GetNullableTypeDisplayText(context.InstanceTypeDisplay)</span>
+                        <span class="cell-text">@context.InstanceTypeDisplay</span>
                     </MudStack>
                 </MudTooltip>
             </MudTd>
@@ -50,14 +50,14 @@
                 {
                     <MudTooltip Text="@context.GroupId" RootClass="cell-tooltip">
                         <MudChip T="string" Color="Color.Tertiary" Size="Size.Small">
-                            @L.GetGroupDisplayText(context)
+                            @context.GroupIdDisplay
                         </MudChip>
                     </MudTooltip>
                 }
                 else
                 {
                     <MudText Typo="Typo.body2" Color="Color.Secondary" Class="cell-text">
-                        @L.GetGroupDisplayText(context)
+                        @context.GroupIdDisplay
                     </MudText>
                 }
             </MudTd>

--- a/Monica.Framework.UI/UIObservableInstance/Components/StateHistoryTimeline.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Components/StateHistoryTimeline.razor
@@ -1,111 +1,111 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
 @using Monica.UI.UIStackTrace.Components
+@inject IStringLocalizer<ObservableInstanceResource> L
 
-<div class="state-history">
+<div class="history-timeline">
     @if (History == null || !History.Any())
     {
-        <MudAlert Severity="Severity.Info">暂无状态变更记录</MudAlert>
+        <MudAlert Severity="Severity.Info">@L["Shared:States:NoStateHistory"]</MudAlert>
     }
     else
     {
-        <MudTimeline TimelineOrientation="TimelineOrientation.Vertical">
-        @foreach (var entry in History.Take(DisplayLimit))
-        {
-            <MudTimelineItem Color="@entry.HistoryEntryColor"
-                             Icon="@entry.HistoryEntryIcon"
-                             Size="Size.Small">
-                <ItemContent>
-                    <MudStack Spacing="2">
-                        <!-- Timestamp and Entry Type Header -->
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Justify="Justify.SpaceBetween">
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                <MudChip T="string" Color="@entry.HistoryEntryColor" Size="Size.Small">
-                                    @entry.EntryTypeDescription
-                                </MudChip>
-                                @if (entry.LogLevel.HasValue)
-                                {
-                                    <MudTooltip Text="@($"日志级别: {entry.LogLevelText}")">
-                                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
-                                            <MudIcon Icon="@entry.LogLevelIcon" Size="Size.Small" Color="@entry.LogLevelColor" />
-                                        </MudStack>
-                                    </MudTooltip>
-                                }
+        <MudTimeline TimelinePosition="TimelinePosition.Left" TimelineOrientation="TimelineOrientation.Vertical" Reverse="true">
+            @foreach (var entry in History.Take(DisplayLimit))
+            {
+                <MudTimelineItem Color="@entry.HistoryEntryColor" Icon="@entry.HistoryEntryIcon">
+                    <ItemContent>
+                        <MudStack Spacing="2" Class="history-item">
+                            <!-- Header -->
+                            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Start">
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudText Typo="Typo.subtitle2">
+                                        @L.GetEntryTypeDescription(entry)
+                                    </MudText>
+                                    @if (entry.LogLevel.HasValue)
+                                    {
+                                        <MudTooltip Text="@L["Shared:Labels:LogLevel", L.GetLogLevelText(entry.LogLevel)]">
+                                            <MudChip T="string" Size="Size.Small" Color="@entry.LogLevelColor" Icon="@entry.LogLevelIcon">
+                                                @L.GetLogLevelText(entry.LogLevel)
+                                            </MudChip>
+                                        </MudTooltip>
+                                    }
+                                </MudStack>
+                                <MudStack Spacing="0" AlignItems="AlignItems.End">
+                                    <MudText Typo="Typo.body2">@entry.TimestampDisplay</MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L.FormatRelativeTime(entry.Timestamp)</MudText>
+                                </MudStack>
                             </MudStack>
-                            <MudStack Spacing="0" AlignItems="AlignItems.End">
-                                <MudText Typo="Typo.body2">@entry.TimestampDisplay</MudText>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">@entry.RelativeTimeDisplay</MudText>
-                            </MudStack>
-                        </MudStack>
 
-                        <!-- Message -->
-                        @if (!string.IsNullOrEmpty(entry.Message))
-                        {
-                            <MudText Typo="Typo.body2">@entry.Message</MudText>
-                        }
+                            <!-- Message -->
+                            @if (!string.IsNullOrEmpty(entry.Message))
+                            {
+                                <MudText Typo="Typo.body2">@entry.Message</MudText>
+                            }
 
-                        <!-- State Transition -->
-                        @if (entry.IsStateTransition)
-                        {
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                                <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">之前:</MudText>
-                                    <MudText Typo="Typo.body2">@entry.PreviousStateDisplay</MudText>
-                                </MudPaper>
-                                <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Small" Color="Color.Default" />
-                                <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">之后:</MudText>
-                                    <MudText Typo="Typo.body2">@entry.CurrentStateDisplay</MudText>
-                                </MudPaper>
-                            </MudStack>
-                        }
+                            <!-- State Transition -->
+                            @if (entry.IsStateTransition)
+                            {
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                    <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Previous"]:</MudText>
+                                        <MudText Typo="Typo.body2">@entry.PreviousStateDisplay</MudText>
+                                    </MudPaper>
+                                    <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Small" Color="Color.Default" />
+                                    <MudPaper Class="pa-2 flex-grow-1" Elevation="0" Outlined="true">
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:After"]:</MudText>
+                                        <MudText Typo="Typo.body2">@entry.CurrentStateDisplay</MudText>
+                                    </MudPaper>
+                                </MudStack>
+                            }
 
-                        <!-- Exception Details -->
-                        @if (entry.IsException && entry.Exception != null)
-                        {
-                            <MudExpansionPanels>
-                                <MudExpansionPanel>
-                                    <TitleContent>
-                                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                            <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Small" Color="Color.Error" />
-                                            <MudText Typo="Typo.body2">@entry.ExceptionType</MudText>
-                                        </MudStack>
-                                    </TitleContent>
-                                    <ChildContent>
-                                        <MudStack Spacing="2">
-                                            <div>
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary">消息:</MudText>
-                                                <MudText Typo="Typo.body2">@entry.ExceptionMessage</MudText>
-                                            </div>
-                                            @if (!string.IsNullOrEmpty(entry.ExceptionStackTrace))
-                                            {
+                            <!-- Exception Details -->
+                            @if (entry.IsException && entry.Exception != null)
+                            {
+                                <MudExpansionPanels>
+                                    <MudExpansionPanel>
+                                        <TitleContent>
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                                <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Small" Color="Color.Error" />
+                                                <MudText Typo="Typo.body2">@entry.ExceptionType</MudText>
+                                            </MudStack>
+                                        </TitleContent>
+                                        <ChildContent>
+                                            <MudStack Spacing="2">
                                                 <div>
-                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">堆栈跟踪:</MudText>
-                                                    <MudPaper Class="pa-2 mt-1 scroll-panel-sm" Elevation="0" Outlined="true">
-                                                        <StackTraceViewer Message="@entry.ExceptionStackTrace" />
-                                                    </MudPaper>
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:Message"]:</MudText>
+                                                    <MudText Typo="Typo.body2">@entry.ExceptionMessage</MudText>
                                                 </div>
-                                            }
-                                        </MudStack>
-                                    </ChildContent>
-                                </MudExpansionPanel>
-                            </MudExpansionPanels>
-                        }
-                    </MudStack>
-                </ItemContent>
-            </MudTimelineItem>
-        }
-    </MudTimeline>
+                                                @if (!string.IsNullOrEmpty(entry.ExceptionStackTrace))
+                                                {
+                                                    <div>
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Shared:Fields:StackTrace"]:</MudText>
+                                                        <MudPaper Class="pa-2 mt-1 scroll-panel-sm" Elevation="0" Outlined="true">
+                                                            <StackTraceViewer Message="@entry.ExceptionStackTrace" />
+                                                        </MudPaper>
+                                                    </div>
+                                                }
+                                            </MudStack>
+                                        </ChildContent>
+                                    </MudExpansionPanel>
+                                </MudExpansionPanels>
+                            }
+                        </MudStack>
+                    </ItemContent>
+                </MudTimelineItem>
+            }
+        </MudTimeline>
 
-    @if (History.Count > DisplayLimit)
-    {
-        <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
-            <MudButton StartIcon="@Icons.Material.Filled.ExpandMore"
-                      Variant="Variant.Outlined"
-                      Color="Color.Primary"
-                      OnClick="LoadMore">
-                加载更多 (剩余 @(History.Count - DisplayLimit) 条)
-            </MudButton>
-        </MudStack>
+        @if (History.Count > DisplayLimit)
+        {
+            <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
+                <MudButton StartIcon="@Icons.Material.Filled.ExpandMore"
+                          Variant="Variant.Outlined"
+                          Color="Color.Primary"
+                          OnClick="LoadMore">
+                    @L["Shared:Actions:LoadMore", History.Count - DisplayLimit]
+                </MudButton>
+            </MudStack>
         }
     }
 </div>

--- a/Monica.Framework.UI/UIObservableInstance/Dialogs/ObservableInstanceDetailDialog.razor
+++ b/Monica.Framework.UI/UIObservableInstance/Dialogs/ObservableInstanceDetailDialog.razor
@@ -1,10 +1,12 @@
+@using Monica.Framework.UI.Localization
 @using Monica.Framework.UI.UIObservableInstance.Models
+@inject IStringLocalizer<ObservableInstanceResource> L
 
 <MudDialog>
     <TitleContent>
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
             <MudIcon Icon="@Icons.Material.Filled.Info" />
-            <MudText Typo="Typo.h6">实例详情</MudText>
+            <MudText Typo="Typo.h6">@L["Detail:Title"]</MudText>
         </MudStack>
     </TitleContent>
     <DialogContent>
@@ -14,11 +16,11 @@
         }
         else
         {
-            <MudAlert Severity="Severity.Info">未选择实例</MudAlert>
+            <MudAlert Severity="Severity.Info">@L["Shared:States:NoInstanceSelected"]</MudAlert>
         }
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="Close" Color="Color.Primary">关闭</MudButton>
+        <MudButton OnClick="Close" Color="Color.Primary">@L["Shared:Actions:Close"]</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/Monica.Framework.UI/UIObservableInstance/Models/ObservableInstanceViewModel.cs
+++ b/Monica.Framework.UI/UIObservableInstance/Models/ObservableInstanceViewModel.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Monica.Core.Localization.Services;
+using Monica.Framework.UI.Localization;
 using Monica.Framework.UI.UIObservableInstance.Support;
 using Monica.Tool.Extensions;
 using MudBlazor;
@@ -129,7 +131,7 @@ public class ObservableInstanceViewModel
     /// <summary>
     /// Short type name using GetCleanName()
     /// </summary>
-    public string InstanceTypeDisplay => InstanceType?.GetCleanName() ?? "Unknown";
+    public string InstanceTypeDisplay => InstanceType?.GetCleanName() ?? LocalizationManager.Get<ObservableInstanceResource>("Shared:Labels:Unknown");
 
     /// <summary>
     /// Full type name using GetCleanFullName()
@@ -139,7 +141,7 @@ public class ObservableInstanceViewModel
     /// <summary>
     /// Handles null/empty GroupId gracefully
     /// </summary>
-    public string GroupIdDisplay => string.IsNullOrEmpty(GroupId) ? "Ungrouped" : GroupId;
+    public string GroupIdDisplay => string.IsNullOrEmpty(GroupId) ? LocalizationManager.Get<ObservableInstanceResource>("Shared:Labels:Ungrouped") : GroupId;
 
     /// <summary>
     /// Formatted registered timestamp
@@ -166,7 +168,7 @@ public class ObservableInstanceViewModel
     /// <summary>
     /// Log level text for display
     /// </summary>
-    public string LogLevelText => CurrentLogLevel?.ToString() ?? "Unknown";
+    public string LogLevelText => LocalizationManager.For<ObservableInstanceResource>().GetLogLevelText(CurrentLogLevel);
 
     /// <summary>
     /// MudBlazor color for log level
@@ -181,12 +183,7 @@ public class ObservableInstanceViewModel
     /// <summary>
     /// Health state text
     /// </summary>
-    public string HealthStateText => HealthState switch
-    {
-        HealthState.Healthy => "健康",
-        HealthState.Unhealthy => "不健康",
-        _ => "未知"
-    };
+    public string HealthStateText => LocalizationManager.For<ObservableInstanceResource>().GetHealthStateText(HealthState);
 
     /// <summary>
     /// MudBlazor color for health state
@@ -210,7 +207,7 @@ public class ObservableInstanceViewModel
     /// <summary>
     /// Exception status badge text
     /// </summary>
-    public string ExceptionStatusText => HasExceptions ? $"{ExceptionCount} 异常" : "正常";
+    public string ExceptionStatusText => LocalizationManager.For<ObservableInstanceResource>().GetExceptionStatusText(HasExceptions, ExceptionCount);
 
     #endregion
 
@@ -261,13 +258,7 @@ public class ObservableInstanceViewModel
     /// </summary>
     private static string FormatDuration(TimeSpan duration)
     {
-        if (duration.TotalDays >= 1)
-            return $"{(int)duration.TotalDays}天 {duration.Hours}小时";
-        if (duration.TotalHours >= 1)
-            return $"{(int)duration.TotalHours}小时 {duration.Minutes}分钟";
-        if (duration.TotalMinutes >= 1)
-            return $"{(int)duration.TotalMinutes}分钟 {duration.Seconds}秒";
-        return $"{(int)duration.TotalSeconds}秒";
+        return LocalizationManager.For<ObservableInstanceResource>().FormatDuration(duration);
     }
 
     #endregion

--- a/Monica.Framework.UI/UIObservableInstance/Models/ObservableStateHistoryViewModel.cs
+++ b/Monica.Framework.UI/UIObservableInstance/Models/ObservableStateHistoryViewModel.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Monica.Core.Localization.Services;
+using Monica.Framework.UI.Localization;
 using Monica.Core.Extensions;
 using Monica.Framework.UI.UIObservableInstance.Support;
 using Monica.Tool.Extensions;
@@ -85,24 +87,7 @@ public class ObservableStateHistoryViewModel
     /// <summary>
     /// Relative time display ("2 minutes ago" format)
     /// </summary>
-    public string RelativeTimeDisplay
-    {
-        get
-        {
-            var elapsed = DateTime.UtcNow - Timestamp;
-
-            if (elapsed.TotalSeconds < 60)
-                return $"{(int)elapsed.TotalSeconds}秒前";
-            if (elapsed.TotalMinutes < 60)
-                return $"{(int)elapsed.TotalMinutes}分钟前";
-            if (elapsed.TotalHours < 24)
-                return $"{(int)elapsed.TotalHours}小时前";
-            if (elapsed.TotalDays < 7)
-                return $"{(int)elapsed.TotalDays}天前";
-
-            return TimestampDisplay;
-        }
-    }
+    public string RelativeTimeDisplay => LocalizationManager.For<ObservableInstanceResource>().FormatRelativeTime(Timestamp);
 
     /// <summary>
     /// Exception message (if exception exists)
@@ -139,7 +124,7 @@ public class ObservableStateHistoryViewModel
     /// <summary>
     /// Log level text for display
     /// </summary>
-    public string LogLevelText => LogLevel?.ToString() ?? "Unknown";
+    public string LogLevelText => LocalizationManager.For<ObservableInstanceResource>().GetLogLevelText(LogLevel);
 
     /// <summary>
     /// Log level color
@@ -191,13 +176,7 @@ public class ObservableStateHistoryViewModel
     /// <summary>
     /// Entry type description
     /// </summary>
-    public string EntryTypeDescription => (IsException, IsStateTransition) switch
-    {
-        (true, true) => "状态变更（异常）",
-        (true, false) => "异常",
-        (false, true) => "状态变更",
-        (false, false) => "消息"
-    };
+    public string EntryTypeDescription => LocalizationManager.For<ObservableInstanceResource>().GetEntryTypeDescription(this);
 
     #endregion
 


### PR DESCRIPTION
## Summary
- Add dedicated Observable Instance UI localization resources for English and Chinese.
- Replace hard-coded Observable Instance UI text with `IStringLocalizer<ObservableInstanceResource>` lookups.
- Localize status, health, log-level, duration, empty-state, dialog, filter, statistics, table, detail, history, and exception display text.
- Fully localize the zh-CN page/header title as `可观测实例监控`.

## Verification
- `python3 -m json.tool Monica.Framework.UI/Localization/ObservableInstanceResource/en-US.json`
- `python3 -m json.tool Monica.Framework.UI/Localization/ObservableInstanceResource/zh-CN.json`
- `dotnet build /root/MoLibrary/Monica.Framework.UI/Monica.Framework.UI.csproj -m` — 0 warnings / 0 errors
- `dotnet build /root/MoLibrary/Monica.slnx -m` — 0 warnings / 0 errors
- `dotnet test /root/MoLibrary/Monica.slnx --no-build` — 31/31 tests passed
- Manual Monica.Docs bridge verification at `/observable-instance-monitor`

## Screenshots
- zh-CN and en-US screenshots were captured locally under `.task-plans/observable-instance-i18n/` for acceptance.
