### PR TITLE
fix: improve job instance detail layout

### DIFF
--- a/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
+++ b/Monica.JobScheduler.UI/Components/JobInstanceDetailDialog.razor
@@ -64,14 +64,16 @@
                 <MudText Typo="Typo.h6" Class="mb-3">@L["Dialogs:JobInstanceDetail:BasicInfo"]</MudText>
                 <MudGrid>
                     <MudItem xs="12" sm="6" md="4">
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:InstanceId"]</MudText>
-                        <MudTooltip Text="@_jobInstance.InstanceId">
-                            <MudLink Typo="Typo.body1"
-                                     Style="display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; cursor: pointer;"
-                                     OnClick="CopyInstanceIdAsync">
-                                @_jobInstance.InstanceId
-                            </MudLink>
-                        </MudTooltip>
+                        <MudStack Spacing="1">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:InstanceId"]</MudText>
+                            <MudTooltip Text="@_jobInstance.InstanceId">
+                                <MudLink Typo="Typo.body1"
+                                         Style="display: inline-block; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; cursor: pointer;"
+                                         OnClick="CopyInstanceIdAsync">
+                                    @_jobInstance.InstanceId
+                                </MudLink>
+                            </MudTooltip>
+                        </MudStack>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:JobKey"]</MudText>
@@ -82,10 +84,12 @@
                         <MudText Typo="Typo.body1" Style="font-family: monospace; overflow-wrap: anywhere;" title="@_jobInstance.RunningClientId">@(_jobInstance.RunningClientId ?? "-")</MudText>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:State"]</MudText>
-                        <MudChip T="string" Size="Size.Small" Color="@ColorService.GetStateColor(_jobInstance.State)">
-                            @_jobInstance.State
-                        </MudChip>
+                        <MudStack Spacing="1" AlignItems="AlignItems.Start">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:State"]</MudText>
+                            <MudChip T="string" Size="Size.Small" Color="@ColorService.GetStateColor(_jobInstance.State)">
+                                @_jobInstance.State
+                            </MudChip>
+                        </MudStack>
                     </MudItem>
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dialogs:JobInstanceDetail:RetryCount"]</MudText>

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
@@ -138,9 +138,11 @@
             </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="@L["JobInstances:Columns:InstanceId"]">
-                <MudText Typo="Typo.body2" Style="font-family: monospace;">
-                    @context.InstanceId.Substring(0, Math.Min(8, context.InstanceId.Length))...
-                </MudText>
+                <MudTooltip Text="@context.InstanceId">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">
+                        @context.InstanceId.Substring(0, Math.Min(8, context.InstanceId.Length))...
+                    </MudText>
+                </MudTooltip>
             </MudTd>
             <MudTd DataLabel="@L["JobInstances:Columns:JobKey"]">@context.JobKey</MudTd>
             <MudTd DataLabel="@L["JobInstances:Columns:State"]">

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
@@ -140,7 +140,7 @@
             <MudTd DataLabel="@L["JobInstances:Columns:InstanceId"]">
                 <MudTooltip Text="@context.InstanceId">
                     <MudText Typo="Typo.body2" Style="font-family: monospace;">
-                        @context.InstanceId.Substring(0, Math.Min(8, context.InstanceId.Length))...
+                        @(context.InstanceId.Length > 8 ? context.InstanceId[..8] + "..." : context.InstanceId)
                     </MudText>
                 </MudTooltip>
             </MudTd>


### PR DESCRIPTION
## Summary
- Adjust the Job Instance detail dialog so Instance ID renders under its label.
- Adjust the Job Instance detail dialog so Status renders under its label.
- Add a tooltip to the Job Instances list Instance ID cell so hovering the truncated ID shows the full value.

## Verification
- `dotnet build Monica.JobScheduler.UI/Monica.JobScheduler.UI.csproj -m` — 0 warnings / 0 errors
- Monica.Docs bridge verification at `/job-scheduler/instances`
- Visual checks confirmed dialog label/value alignment and list Instance ID full tooltip behavior.

## Screenshots
- Local verification screenshots saved under `.task-plans/job-instance-detail-layout-tooltip/`.
