### PR TITLE
fix: improve job definitions list layout

### DIFF
--- a/Monica.JobScheduler.UI/Localization/JobSchedulerResource/en-US.json
+++ b/Monica.JobScheduler.UI/Localization/JobSchedulerResource/en-US.json
@@ -134,6 +134,17 @@
       "PartialSuccess": "Batch operation completed: {0} succeeded, {1} failed",
       "AllFailed": "Batch operation failed: All operations failed"
     },
+    "NextExecutionTimeTooltip": {
+      "Future": "Executes in {0}",
+      "Past": "Was due {0} ago",
+      "Now": "Due now"
+    },
+    "RelativeTime": {
+      "DaysHours": "{0}d {1}h",
+      "HoursMinutes": "{0}h {1}m",
+      "MinutesSeconds": "{0}m {1}s",
+      "Seconds": "{0}s"
+    },
     "Messages": {
       "NoRecurringJobs": "No matching recurring jobs found",
       "NoTriggerJobs": "No matching triggered jobs found",

--- a/Monica.JobScheduler.UI/Localization/JobSchedulerResource/zh-CN.json
+++ b/Monica.JobScheduler.UI/Localization/JobSchedulerResource/zh-CN.json
@@ -134,6 +134,17 @@
       "PartialSuccess": "批量操作完成: {0} 成功, {1} 失败",
       "AllFailed": "批量操作失败: 所有操作均失败"
     },
+    "NextExecutionTimeTooltip": {
+      "Future": "将在 {0} 后执行",
+      "Past": "已到期 {0}",
+      "Now": "现在到期"
+    },
+    "RelativeTime": {
+      "DaysHours": "{0}天 {1}小时",
+      "HoursMinutes": "{0}小时 {1}分钟",
+      "MinutesSeconds": "{0}分钟 {1}秒",
+      "Seconds": "{0}秒"
+    },
     "Messages": {
       "NoRecurringJobs": "没有找到匹配的周期性作业",
       "NoTriggerJobs": "没有找到匹配的触发型作业",

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor
@@ -17,7 +17,7 @@
 
 @using Monica.UI.Shell.State
 
-<MudContainer MaxWidth="MaxWidth.ExtraExtraLarge" Class="mt-4">
+<MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
     <MudText Typo="Typo.h4" Class="mb-4">@L["JobDefinitions:Title"]</MudText>
 
     <!-- filter -->
@@ -113,6 +113,7 @@
                  Rounded="true"
                  ApplyEffectsToContainer="true">
             <MudTabPanel Text="@L["JobDefinitions:Tabs:RecurringJob"]" Icon="@Icons.Material.Filled.Schedule" PanelClass="pa-6">
+            <div class="job-definitions-table-wrapper recurring-job-definitions-table">
             <MudTable @ref="_recurringTable"
                       T="JobDefinitionWithLastExecution"
                       ServerData="LoadRecurringJobsAsync"
@@ -131,50 +132,54 @@
                                    OnClick="RefreshRecurringJobsAsync" />
                 </ToolBarContent>
                 <HeaderContent>
-                    <MudTh><MudTableSortLabel SortLabel="FromProject" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:SourceProject"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="JobKey" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobKey"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="JobName" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobName"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="CronExpression" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:CronExpression"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="NextExecutionTime" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:NextExecutionTime"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="LastExecution" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:LastExecutionTime"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="IsDisabled" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:Status"]</MudTableSortLabel></MudTh>
-                    <MudTh>@L["JobDefinitions:Columns:Actions"]</MudTh>
+                    <MudTh Class="job-source-column"><MudTableSortLabel SortLabel="FromProject" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:SourceProject"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-key-column"><MudTableSortLabel SortLabel="JobKey" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobKey"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-name-column"><MudTableSortLabel SortLabel="JobName" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobName"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-cron-column"><MudTableSortLabel SortLabel="CronExpression" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:CronExpression"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-next-column"><MudTableSortLabel SortLabel="NextExecutionTime" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:NextExecutionTime"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-last-column"><MudTableSortLabel SortLabel="LastExecution" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:LastExecutionTime"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-status-column"><MudTableSortLabel SortLabel="IsDisabled" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:Status"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-actions-column">@L["JobDefinitions:Columns:Actions"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:SourceProject"]">@context.Definition.FromProject</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
-                        <MudTooltip Text="@context.Definition.JobKey">
+                    <MudTd Class="job-source-column" DataLabel="@L["JobDefinitions:Columns:SourceProject"]"><span class="job-cell-text">@context.Definition.FromProject</span></MudTd>
+                    <MudTd Class="job-key-column" DataLabel="@L["JobDefinitions:Columns:JobKey"]">
+                        <MudTooltip Text="@context.Definition.JobKey" RootClass="job-cell-tooltip">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     Color="Color.Inherit"
+                                     Class="job-cell-link"
                                      OnClick="() => CopyJobKeyAsync(context.Definition.JobKey)">
                                 @context.Definition.JobKey
                             </MudLink>
                         </MudTooltip>
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
-                        <MudTooltip Text="@context.Definition.JobName">
+                    <MudTd Class="job-name-column" DataLabel="@L["JobDefinitions:Columns:JobName"]">
+                        <MudTooltip Text="@context.Definition.JobName" RootClass="job-cell-tooltip">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     Color="Color.Inherit"
+                                     Class="job-cell-link job-name-link"
                                      OnClick="() => NavigateToDetail(context.Definition.JobKey)">
                                 @context.Definition.JobName
                             </MudLink>
                         </MudTooltip>
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:CronExpression"]">
+                    <MudTd Class="job-cron-column" DataLabel="@L["JobDefinitions:Columns:CronExpression"]">
                         <CronExpressionDisplay Expression="@context.Definition.CronExpression"
                                                DisplayMode="CronDisplayMode.Compact" />
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:NextExecutionTime"]">
+                    <MudTd Class="job-next-column" DataLabel="@L["JobDefinitions:Columns:NextExecutionTime"]">
                         @if (context.NextExecutionTime.HasValue)
                         {
-                            <MudText Typo="Typo.body2">@context.NextExecutionTime.Value.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss")</MudText>
+                            <MudTooltip Text="@GetNextExecutionTimeTooltip(context.NextExecutionTime.Value)" RootClass="job-cell-tooltip">
+                                <MudText Typo="Typo.body2" Class="job-time-text">@context.NextExecutionTime.Value.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss")</MudText>
+                            </MudTooltip>
                         }
                         else
                         {
                             <MudText Typo="Typo.body2" Color="Color.Secondary">-</MudText>
                         }
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:LastExecutionTime"]">
+                    <MudTd Class="job-last-column" DataLabel="@L["JobDefinitions:Columns:LastExecutionTime"]">
                         @if (context.LastExecution != null)
                         {
                             <div class="last-execution-wrapper">
@@ -192,13 +197,13 @@
                             <MudText Typo="Typo.body2" Color="Color.Secondary">-</MudText>
                         }
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:Status"]">
+                    <MudTd Class="job-status-column" DataLabel="@L["JobDefinitions:Columns:Status"]">
                         <MudChip T="string" Size="Size.Small" Color="@GetDisabledStateColor(context.Definition.IsDisabled)">
                             @(context.Definition.IsDisabled ? L["JobDefinitions:Status:Disabled"] : L["JobDefinitions:Status:Enabled"])
                         </MudChip>
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:Actions"]">
-                        <MudStack Row="true" Spacing="1">
+                    <MudTd Class="job-actions-column" DataLabel="@L["JobDefinitions:Columns:Actions"]">
+                        <MudStack Row="true" Spacing="1" Class="job-actions-stack">
                             @if (context.Definition.IsDisabled)
                             {
                                 <MudTooltip Text="@L["JobDefinitions:Actions:Resume"]">
@@ -242,9 +247,11 @@
                     <MudTablePager PageSizeOptions="new int[] { 10, 20, 50, 100 }" />
                 </PagerContent>
             </MudTable>
+            </div>
         </MudTabPanel>
 
         <MudTabPanel Text="@L["JobDefinitions:Tabs:TriggerJob"]" Icon="@Icons.Material.Filled.TouchApp" PanelClass="pa-6">
+            <div class="job-definitions-table-wrapper trigger-job-definitions-table">
             <MudTable @ref="_triggerTable"
                       T="JobDefinitionWithLastExecution"
                       ServerData="LoadTriggerJobsAsync"
@@ -260,33 +267,35 @@
                                    OnClick="RefreshTriggerJobsAsync" />
                 </ToolBarContent>
                 <HeaderContent>
-                    <MudTh><MudTableSortLabel SortLabel="FromProject" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:SourceProject"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="JobKey" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobKey"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="JobName" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobName"]</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="LastExecution" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:LastExecutionTime"]</MudTableSortLabel></MudTh>
-                    <MudTh>@L["JobDefinitions:Columns:Actions"]</MudTh>
+                    <MudTh Class="job-source-column"><MudTableSortLabel SortLabel="FromProject" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:SourceProject"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-key-column"><MudTableSortLabel SortLabel="JobKey" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobKey"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-name-column"><MudTableSortLabel SortLabel="JobName" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:JobName"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-last-column"><MudTableSortLabel SortLabel="LastExecution" T="JobDefinitionWithLastExecution">@L["JobDefinitions:Columns:LastExecutionTime"]</MudTableSortLabel></MudTh>
+                    <MudTh Class="job-actions-column">@L["JobDefinitions:Columns:Actions"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:SourceProject"]">@context.Definition.FromProject</MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobKey"]">
-                        <MudTooltip Text="@context.Definition.JobKey">
+                    <MudTd Class="job-source-column" DataLabel="@L["JobDefinitions:Columns:SourceProject"]"><span class="job-cell-text">@context.Definition.FromProject</span></MudTd>
+                    <MudTd Class="job-key-column" DataLabel="@L["JobDefinitions:Columns:JobKey"]">
+                        <MudTooltip Text="@context.Definition.JobKey" RootClass="job-cell-tooltip">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     Color="Color.Inherit"
+                                     Class="job-cell-link"
                                      OnClick="() => CopyJobKeyAsync(context.Definition.JobKey)">
                                 @context.Definition.JobKey
                             </MudLink>
                         </MudTooltip>
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:JobName"]">
-                        <MudTooltip Text="@context.Definition.JobName">
+                    <MudTd Class="job-name-column" DataLabel="@L["JobDefinitions:Columns:JobName"]">
+                        <MudTooltip Text="@context.Definition.JobName" RootClass="job-cell-tooltip">
                             <MudLink Typo="Typo.body2"
-                                     Style="display: inline-block; max-width: 22rem; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; cursor: pointer;"
+                                     Color="Color.Inherit"
+                                     Class="job-cell-link job-name-link"
                                      OnClick="() => NavigateToDetail(context.Definition.JobKey)">
                                 @context.Definition.JobName
                             </MudLink>
                         </MudTooltip>
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:LastExecutionTime"]">
+                    <MudTd Class="job-last-column" DataLabel="@L["JobDefinitions:Columns:LastExecutionTime"]">
                         @if (context.LastExecution != null)
                         {
                             <div class="last-execution-wrapper">
@@ -304,8 +313,8 @@
                             <MudText Typo="Typo.body2" Color="Color.Secondary">-</MudText>
                         }
                     </MudTd>
-                    <MudTd DataLabel="@L["JobDefinitions:Columns:Actions"]">
-                        <MudStack Row="true" Spacing="1">
+                    <MudTd Class="job-actions-column" DataLabel="@L["JobDefinitions:Columns:Actions"]">
+                        <MudStack Row="true" Spacing="1" Class="job-actions-stack">
                             <MudTooltip Text="@L["JobDefinitions:Actions:Execute"]">
                                 <MudIconButton Icon="@Icons.Material.Filled.PlayCircle"
                                                Color="Color.Primary"
@@ -331,6 +340,7 @@
                     <MudTablePager PageSizeOptions="new int[] { 10, 20, 50, 100 }" />
                 </PagerContent>
             </MudTable>
+            </div>
             </MudTabPanel>
         </MudTabs>
     }
@@ -654,6 +664,42 @@
     private void NavigateToDetail(string jobKey)
     {
         NavigationManager.NavigateTo($"/job-scheduler/definitions/{Uri.EscapeDataString(jobKey)}");
+    }
+
+    private string GetNextExecutionTimeTooltip(DateTime nextExecutionTime)
+    {
+        var distance = nextExecutionTime - DateTime.UtcNow;
+        var absoluteDistance = distance.Duration();
+
+        if (absoluteDistance < TimeSpan.FromSeconds(1))
+        {
+            return L["JobDefinitions:NextExecutionTimeTooltip:Now"];
+        }
+
+        var formattedDistance = FormatRelativeDistance(absoluteDistance);
+        return distance >= TimeSpan.Zero
+            ? L["JobDefinitions:NextExecutionTimeTooltip:Future", formattedDistance]
+            : L["JobDefinitions:NextExecutionTimeTooltip:Past", formattedDistance];
+    }
+
+    private string FormatRelativeDistance(TimeSpan distance)
+    {
+        if (distance.TotalDays >= 1)
+        {
+            return L["JobDefinitions:RelativeTime:DaysHours", (int)distance.TotalDays, distance.Hours];
+        }
+
+        if (distance.TotalHours >= 1)
+        {
+            return L["JobDefinitions:RelativeTime:HoursMinutes", (int)distance.TotalHours, distance.Minutes];
+        }
+
+        if (distance.TotalMinutes >= 1)
+        {
+            return L["JobDefinitions:RelativeTime:MinutesSeconds", (int)distance.TotalMinutes, distance.Seconds];
+        }
+
+        return L["JobDefinitions:RelativeTime:Seconds", Math.Max(1, (int)Math.Ceiling(distance.TotalSeconds))];
     }
 
     private async Task OpenInstanceDetailDialog(string instanceId)

--- a/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor.css
+++ b/Monica.JobScheduler.UI/Pages/JobDefinitionsPage.razor.css
@@ -1,3 +1,148 @@
+.recurring-job-definitions-table {
+    --table-columns:
+        minmax(3rem, 0.25fr)
+        minmax(8rem, 0.9fr)
+        minmax(9rem, 1.25fr)
+        minmax(10rem, 1.45fr)
+        minmax(9rem, 0.95fr)
+        minmax(11rem, 1.1fr)
+        minmax(11rem, 1.1fr)
+        minmax(6.5rem, 0.65fr)
+        minmax(8.5rem, 0.75fr);
+}
+
+.trigger-job-definitions-table {
+    --table-columns:
+        minmax(8rem, 0.9fr)
+        minmax(10rem, 1.45fr)
+        minmax(12rem, 1.75fr)
+        minmax(11rem, 1.1fr)
+        minmax(8.5rem, 0.75fr);
+}
+
+.job-definitions-table-wrapper ::deep .mud-table-root {
+    width: 100%;
+}
+
+.job-definitions-table-wrapper ::deep .mud-table-container {
+    overflow-x: auto;
+}
+
+@media (min-width: 961px) {
+    .job-definitions-table-wrapper ::deep .mud-table-root {
+        display: grid;
+        grid-template-columns: var(--table-columns);
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-head,
+    .job-definitions-table-wrapper ::deep .mud-table-body,
+    .job-definitions-table-wrapper ::deep .mud-table-row {
+        display: contents;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-cell {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-cell > * {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-loading,
+    .job-definitions-table-wrapper ::deep .mud-table-empty-row {
+        grid-column: 1 / -1;
+        display: block;
+        width: 100%;
+        min-width: 0;
+        justify-content: center;
+        text-align: center;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-body tr:has(.mud-table-empty-row) {
+        display: contents;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-empty-row > * {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-body .job-cron-column,
+    .job-definitions-table-wrapper ::deep .mud-table-body .job-last-column:has(.last-execution-wrapper),
+    .job-definitions-table-wrapper ::deep .mud-table-body .job-status-column {
+        padding-left: 8px;
+    }
+}
+
+@media (max-width: 960px) {
+    .job-definitions-table-wrapper ::deep .mud-table-root,
+    .job-definitions-table-wrapper ::deep .mud-table-body,
+    .job-definitions-table-wrapper ::deep .mud-table-row {
+        display: block;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-cell {
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
+    }
+
+    .job-definitions-table-wrapper ::deep .mud-table-container {
+        overflow-x: hidden;
+    }
+}
+
+.job-definitions-table-wrapper ::deep .job-cell-text,
+.job-definitions-table-wrapper ::deep .job-cell-link,
+.job-definitions-table-wrapper ::deep .job-time-text {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.job-definitions-table-wrapper ::deep .job-cell-tooltip {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.job-definitions-table-wrapper ::deep .job-cell-link {
+    color: inherit;
+    cursor: pointer;
+}
+
+.job-definitions-table-wrapper ::deep .job-cell-link:hover,
+.job-definitions-table-wrapper ::deep .job-cell-link:focus-visible {
+    color: inherit;
+}
+
+.job-definitions-table-wrapper ::deep .job-name-link {
+    font-weight: 700;
+}
+
+.job-definitions-table-wrapper ::deep .job-actions-stack {
+    align-items: center;
+    flex-wrap: nowrap;
+}
+
+.last-execution-wrapper {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+}
+
 .last-execution-wrapper ::deep .clickable-execution-time {
     cursor: pointer;
     transition: transform 0.15s ease-in-out, box-shadow 0.15s ease-in-out;

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
@@ -15,7 +15,7 @@
 
 @using Monica.UI.Shell.State
 
-<MudContainer MaxWidth="MaxWidth.ExtraExtraLarge" Class="mt-4">
+<MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
     <MudText Typo="Typo.h4" Class="mb-4">@L["JobInstances:Title"]</MudText>
 
     <!-- filter -->


### PR DESCRIPTION
## Summary
- improve Job Definitions table layout with scoped CSS-grid columns and adaptive ellipsis for Job Key / Job Name
- keep Job Key copy and Job Name navigation while making Job Name bold and inherited-color
- add localized relative-time tooltip for Next Execution Time
- widen Cron / execution time / status / actions columns and align badges/icons/text consistently
- remove page-level `MaxWidth.ExtraExtraLarge` limit from Job Definitions and Job Instances pages

## Verification
- `git diff --check`
- `dotnet build Monica.JobScheduler.UI/Monica.JobScheduler.UI.csproj -m`
- Browser verified via Monica.Docs bridge: `http://127.0.0.1:5298/job-scheduler/definitions`
- Screenshots saved under `.task-plans/job-definitions-list-layout/` locally
