### PR TITLE
fix: improve list overflow handling

### DIFF
--- a/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
+++ b/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
@@ -28,13 +28,32 @@
         }
         else if (_projectUnits.Any())
         {
+            <div class="project-units-monitor-grid">
             <MudDataGrid T="DtoProjectUnit" Items="@_projectUnits" Filterable="true"
                         SortMode="SortMode.Multiple" Groupable="true" GroupExpanded="false"
                         Dense="true" Hover="true" ReadOnly="true">
                 <Columns>
-                    <PropertyColumn Property="x => x.Title" Title="@L["ProjectUnitMonitor:Columns:Name"]" />
-                    <PropertyColumn Property="x => x.Key" Title="@L["ProjectUnitMonitor:Columns:FullName"]" />
-                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Type"]">
+                    <PropertyColumn T="DtoProjectUnit" TProperty="string" Property="x => x.Title" Title="@L["ProjectUnitMonitor:Columns:Name"]"
+                                    HeaderClass="project-units-monitor-grid__name-column"
+                                    CellClass="project-units-monitor-grid__name-column">
+                        <CellTemplate>
+                            <MudTooltip Text="@context.Item.Title">
+                                <span class="project-units-monitor-grid__ellipsis">@context.Item.Title</span>
+                            </MudTooltip>
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn T="DtoProjectUnit" TProperty="string" Property="x => x.Key" Title="@L["ProjectUnitMonitor:Columns:FullName"]"
+                                    HeaderClass="project-units-monitor-grid__full-name-column"
+                                    CellClass="project-units-monitor-grid__full-name-column">
+                        <CellTemplate>
+                            <MudTooltip Text="@context.Item.Key">
+                                <span class="project-units-monitor-grid__ellipsis">@context.Item.Key</span>
+                            </MudTooltip>
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Type"]"
+                                    HeaderClass="project-units-monitor-grid__type-column"
+                                    CellClass="project-units-monitor-grid__type-column">
                         <CellTemplate>
                             <MudChip T="string" Size="Size.Small"
                                      Color="@ProjectUnitVisualizationConfig.GetUnitTypeMudColor(context.Item.UnitType)">
@@ -42,7 +61,9 @@
                             </MudChip>
                         </CellTemplate>
                     </TemplateColumn>
-                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Dependencies"]" Sortable="false">
+                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Dependencies"]" Sortable="false"
+                                    HeaderClass="project-units-monitor-grid__count-column"
+                                    CellClass="project-units-monitor-grid__count-column">
                         <CellTemplate>
                             <MudChip T="int" Size="Size.Small" Color="Color.Info"
                                      Icon="@Icons.Material.Filled.Link">
@@ -50,7 +71,9 @@
                             </MudChip>
                         </CellTemplate>
                     </TemplateColumn>
-                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:DependedBy"]" Sortable="false">
+                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:DependedBy"]" Sortable="false"
+                                    HeaderClass="project-units-monitor-grid__count-column"
+                                    CellClass="project-units-monitor-grid__count-column">
                         <CellTemplate>
                             <MudChip T="int" Size="Size.Small" Color="Color.Success"
                                      Icon="@Icons.Material.Filled.CallReceived">
@@ -58,7 +81,9 @@
                             </MudChip>
                         </CellTemplate>
                     </TemplateColumn>
-                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Actions"]" Sortable="false">
+                    <TemplateColumn Title="@L["ProjectUnitMonitor:Columns:Actions"]" Sortable="false"
+                                    HeaderClass="project-units-monitor-grid__actions-column"
+                                    CellClass="project-units-monitor-grid__actions-column">
                         <CellTemplate>
                             <MudButton Size="Size.Small"
                                       Variant="Variant.Text"
@@ -70,6 +95,7 @@
                     </TemplateColumn>
                 </Columns>
             </MudDataGrid>
+            </div>
         }
         else
         {

--- a/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor.css
+++ b/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor.css
@@ -1,0 +1,87 @@
+.project-units-monitor-grid {
+    --project-units-monitor-columns:
+        minmax(8rem, 1fr)
+        minmax(12rem, 1.6fr)
+        minmax(7rem, 0.7fr)
+        minmax(6.75rem, 0.55fr)
+        minmax(6.75rem, 0.55fr)
+        minmax(6.25rem, 0.45fr);
+}
+
+.project-units-monitor-grid ::deep .mud-table-container {
+    overflow-x: auto;
+}
+
+.project-units-monitor-grid ::deep .mud-table-root {
+    width: 100%;
+}
+
+@media (min-width: 961px) {
+    .project-units-monitor-grid ::deep .mud-table-root {
+        display: grid;
+        grid-template-columns: var(--project-units-monitor-columns);
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-head,
+    .project-units-monitor-grid ::deep .mud-table-body,
+    .project-units-monitor-grid ::deep .mud-table-row {
+        display: contents;
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-cell {
+        align-items: center;
+        display: flex;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-cell > * {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-loading,
+    .project-units-monitor-grid ::deep .mud-table-empty-row,
+    .project-units-monitor-grid ::deep .mud-table-child-content,
+    .project-units-monitor-grid ::deep .mud-table-group-row {
+        grid-column: 1 / -1;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-body tr:has(.mud-table-empty-row),
+    .project-units-monitor-grid ::deep .mud-table-body tr:has(.mud-table-child-content),
+    .project-units-monitor-grid ::deep .mud-table-body tr:has(.mud-table-group-row) {
+        display: contents;
+    }
+
+    .project-units-monitor-grid ::deep .mud-table-empty-row > *,
+    .project-units-monitor-grid ::deep .mud-table-child-content > *,
+    .project-units-monitor-grid ::deep .mud-table-group-row > * {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .project-units-monitor-grid ::deep .column-header,
+    .project-units-monitor-grid ::deep .sortable-column-header,
+    .project-units-monitor-grid ::deep .mud-table-cell.project-units-monitor-grid__name-column,
+    .project-units-monitor-grid ::deep .mud-table-cell.project-units-monitor-grid__full-name-column {
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .project-units-monitor-grid ::deep .project-units-monitor-grid__type-column,
+    .project-units-monitor-grid ::deep .project-units-monitor-grid__count-column,
+    .project-units-monitor-grid ::deep .project-units-monitor-grid__actions-column {
+        justify-content: center;
+    }
+}
+
+.project-units-monitor-grid__ellipsis {
+    display: block;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
@@ -106,6 +106,7 @@
     <!-- data table with deferred rendering -->
     @if (_stateLoaded)
     {
+        <div class="job-instances-table-wrapper">
         <MudTable @ref="_table"
                   T="JobInstance"
                   ServerData="LoadDataAsync"
@@ -127,55 +128,58 @@
                                OnClick="RefreshAsync" />
             </ToolBarContent>
             <HeaderContent>
-                <MudTh><MudTableSortLabel SortLabel="InstanceId" T="JobInstance">@L["JobInstances:Columns:InstanceId"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="JobKey" T="JobInstance">@L["JobInstances:Columns:JobKey"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="State" T="JobInstance">@L["JobInstances:Columns:State"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="CreatedAt" T="JobInstance" InitialDirection="SortDirection.Descending">@L["JobInstances:Columns:CreatedTime"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="StartedAt" T="JobInstance">@L["JobInstances:Columns:StartTime"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="CompletedAt" T="JobInstance">@L["JobInstances:Columns:EndTime"]</MudTableSortLabel></MudTh>
-                <MudTh><MudTableSortLabel SortLabel="Duration" T="JobInstance">@L["JobInstances:Columns:Duration"]</MudTableSortLabel></MudTh>
-                <MudTh>@L["JobInstances:Columns:Actions"]</MudTh>
+                <MudTh Class="job-instance-id-column"><MudTableSortLabel SortLabel="InstanceId" T="JobInstance">@L["JobInstances:Columns:InstanceId"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-key-column"><MudTableSortLabel SortLabel="JobKey" T="JobInstance">@L["JobInstances:Columns:JobKey"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-state-column"><MudTableSortLabel SortLabel="State" T="JobInstance">@L["JobInstances:Columns:State"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-created-column"><MudTableSortLabel SortLabel="CreatedAt" T="JobInstance" InitialDirection="SortDirection.Descending">@L["JobInstances:Columns:CreatedTime"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-started-column"><MudTableSortLabel SortLabel="StartedAt" T="JobInstance">@L["JobInstances:Columns:StartTime"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-completed-column"><MudTableSortLabel SortLabel="CompletedAt" T="JobInstance">@L["JobInstances:Columns:EndTime"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-duration-column"><MudTableSortLabel SortLabel="Duration" T="JobInstance">@L["JobInstances:Columns:Duration"]</MudTableSortLabel></MudTh>
+                <MudTh Class="job-actions-column">@L["JobInstances:Columns:Actions"]</MudTh>
             </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="@L["JobInstances:Columns:InstanceId"]">
+            @{
+                var createdAtText = context.CreatedAt.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss");
+                var startedAtText = context.StartedAt?.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss") ?? "-";
+                var completedAtText = context.CompletedAt?.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss") ?? "-";
+                var durationText = GetDurationText(context);
+            }
+            <MudTd DataLabel="@L["JobInstances:Columns:InstanceId"]" Class="job-instance-id-column">
                 <MudTooltip Text="@context.InstanceId">
-                    <MudText Typo="Typo.body2" Style="font-family: monospace;">
-                        @(context.InstanceId.Length > 8 ? context.InstanceId[..8] + "..." : context.InstanceId)
-                    </MudText>
+                    <span class="job-instances-table__ellipsis job-instances-table__monospace">@context.InstanceId</span>
                 </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:JobKey"]">@context.JobKey</MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:State"]">
+            <MudTd DataLabel="@L["JobInstances:Columns:JobKey"]" Class="job-key-column">
+                <MudTooltip Text="@context.JobKey">
+                    <span class="job-instances-table__ellipsis">@context.JobKey</span>
+                </MudTooltip>
+            </MudTd>
+            <MudTd DataLabel="@L["JobInstances:Columns:State"]" Class="job-state-column">
                 <MudChip T="string" Size="Size.Small" Color="@ColorService.GetStateColor(context.State)">
                     @context.State
                 </MudChip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:CreatedTime"]">
-                @context.CreatedAt.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss")
+            <MudTd DataLabel="@L["JobInstances:Columns:CreatedTime"]" Class="job-created-column">
+                <MudTooltip Text="@createdAtText">
+                    <span class="job-instances-table__ellipsis">@createdAtText</span>
+                </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:StartTime"]">
-                @(context.StartedAt?.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss") ?? "-")
+            <MudTd DataLabel="@L["JobInstances:Columns:StartTime"]" Class="job-started-column">
+                <MudTooltip Text="@startedAtText">
+                    <span class="job-instances-table__ellipsis">@startedAtText</span>
+                </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:EndTime"]">
-                @(context.CompletedAt?.FromUtcToLocal().ToString("yyyy-MM-dd HH:mm:ss") ?? "-")
+            <MudTd DataLabel="@L["JobInstances:Columns:EndTime"]" Class="job-completed-column">
+                <MudTooltip Text="@completedAtText">
+                    <span class="job-instances-table__ellipsis">@completedAtText</span>
+                </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:Duration"]">
-                @if (context.StartedAt.HasValue && context.CompletedAt.HasValue)
-                {
-                    var duration = context.CompletedAt.Value - context.StartedAt.Value;
-                    <text>@FormatDuration(duration)</text>
-                }
-                else if (context.StartedAt.HasValue)
-                {
-                    var duration = DateTime.UtcNow.FromUtcToLocal() - context.StartedAt.Value.FromUtcToLocal();
-                    <text>@FormatDuration(duration) (@L["JobInstances:Messages:Running"])</text>
-                }
-                else
-                {
-                    <text>-</text>
-                }
+            <MudTd DataLabel="@L["JobInstances:Columns:Duration"]" Class="job-duration-column">
+                <MudTooltip Text="@durationText">
+                    <span class="job-instances-table__ellipsis">@durationText</span>
+                </MudTooltip>
             </MudTd>
-            <MudTd DataLabel="@L["JobInstances:Columns:Actions"]">
+            <MudTd DataLabel="@L["JobInstances:Columns:Actions"]" Class="job-actions-column">
                 <MudTooltip Text="@L["JobInstances:Actions:ViewDetails"]">
                     <MudIconButton Icon="@Icons.Material.Filled.Info"
                                    Color="Color.Info"
@@ -194,6 +198,7 @@
                 <MudTablePager PageSizeOptions="new int[] { 10, 20, 50, 100 }" />
             </PagerContent>
         </MudTable>
+        </div>
     }
     else
     {
@@ -468,6 +473,22 @@
         if (duration.TotalSeconds >= 1)
             return $"{duration.TotalSeconds:F2}s";
         return $"{duration.TotalMilliseconds:F0}ms";
+    }
+
+    private string GetDurationText(JobInstance instance)
+    {
+        if (instance.StartedAt.HasValue && instance.CompletedAt.HasValue)
+        {
+            return FormatDuration(instance.CompletedAt.Value - instance.StartedAt.Value);
+        }
+
+        if (instance.StartedAt.HasValue)
+        {
+            var duration = DateTime.UtcNow.FromUtcToLocal() - instance.StartedAt.Value.FromUtcToLocal();
+            return $"{FormatDuration(duration)} ({L["JobInstances:Messages:Running"]})";
+        }
+
+        return "-";
     }
 
     private static string? MapSortLabelToField(string sortLabel)

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor
@@ -484,7 +484,7 @@
 
         if (instance.StartedAt.HasValue)
         {
-            var duration = DateTime.UtcNow.FromUtcToLocal() - instance.StartedAt.Value.FromUtcToLocal();
+            var duration = DateTime.UtcNow - instance.StartedAt.Value;
             return $"{FormatDuration(duration)} ({L["JobInstances:Messages:Running"]})";
         }
 

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor.css
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor.css
@@ -1,0 +1,81 @@
+.job-instances-table-wrapper {
+    --table-columns:
+        minmax(8rem, 1fr)
+        minmax(8rem, 0.95fr)
+        minmax(7rem, 0.65fr)
+        minmax(10rem, 1fr)
+        minmax(10rem, 1fr)
+        minmax(10rem, 1fr)
+        minmax(7rem, 0.65fr)
+        minmax(5.25rem, 0.45fr);
+}
+
+.job-instances-table-wrapper ::deep .mud-table-root {
+    width: 100%;
+}
+
+.job-instances-table-wrapper ::deep .mud-table-container {
+    overflow-x: auto;
+}
+
+@media (min-width: 961px) {
+    .job-instances-table-wrapper ::deep .mud-table-root {
+        display: grid;
+        grid-template-columns: var(--table-columns);
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-head,
+    .job-instances-table-wrapper ::deep .mud-table-body,
+    .job-instances-table-wrapper ::deep .mud-table-row {
+        display: contents;
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-cell {
+        align-items: center;
+        display: flex;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-cell > * {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-loading,
+    .job-instances-table-wrapper ::deep .mud-table-empty-row {
+        display: block;
+        grid-column: 1 / -1;
+        justify-content: center;
+        min-width: 0;
+        text-align: center;
+        width: 100%;
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-body tr:has(.mud-table-empty-row) {
+        display: contents;
+    }
+
+    .job-instances-table-wrapper ::deep .mud-table-empty-row > * {
+        max-width: 100%;
+        width: 100%;
+    }
+
+    .job-instances-table-wrapper ::deep .job-state-column,
+    .job-instances-table-wrapper ::deep .job-actions-column {
+        justify-content: center;
+    }
+}
+
+.job-instances-table__ellipsis {
+    display: block;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.job-instances-table__monospace {
+    font-family: var(--mud-typography-default-family), monospace;
+}

--- a/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor.css
+++ b/Monica.JobScheduler.UI/Pages/JobInstancesPage.razor.css
@@ -77,5 +77,5 @@
 }
 
 .job-instances-table__monospace {
-    font-family: var(--mud-typography-default-family), monospace;
+    font-family: monospace;
 }

--- a/Monica.UI/Pages/UISystemInfoPage.razor
+++ b/Monica.UI/Pages/UISystemInfoPage.razor
@@ -197,7 +197,13 @@
                                         <MudIcon Icon="@Icons.Material.Filled.Tag" Size="Size.Small" Color="Color.Info" />
                                         <MudText><strong>@L["Page:FileInfo:ProductVersion"]:</strong></MudText>
                                     </MudStack>
-                                    <MudText Class="ml-6" Style="color: var(--mud-palette-text-secondary);">@_systemInfo.FileInfo.ProductVersion</MudText>
+                                    <div class="system-info-file-version-value">
+                                        <MudTooltip Text="@_systemInfo.FileInfo.ProductVersion">
+                                            <MudText Class="ml-6" Color="Color.Secondary">
+                                                @_systemInfo.FileInfo.ProductVersion
+                                            </MudText>
+                                        </MudTooltip>
+                                    </div>
 
                                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                         <MudIcon Icon="@Icons.Material.Filled.Code" Size="Size.Small" Color="Color.Warning" />

--- a/Monica.UI/Pages/UISystemInfoPage.razor.css
+++ b/Monica.UI/Pages/UISystemInfoPage.razor.css
@@ -1,0 +1,6 @@
+.system-info-file-version-value {
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- add scoped adaptive grid/min-width layout for Project Units monitor table with tooltips for truncated unit name/full name
- add scoped adaptive layout for Job Instances table, removing hard-coded Instance ID substring truncation and using CSS ellipsis + tooltips
- prevent long System Info product version values from overflowing the file info card, with tooltip for the full value

## Verification
- `git diff --check`
- `dotnet build Monica.JobScheduler.UI/Monica.JobScheduler.UI.csproj -m`
- `dotnet build Monica.Framework.UI/Monica.Framework.UI.csproj -m`
- `dotnet build Monica.UI/Monica.UI.csproj -m`
- Browser verified via Monica.Docs bridge:
  - `/project-units`
  - `/job-scheduler/instances`
  - `/system-info`
- Screenshots saved locally under `.task-plans/list-layout-overflow/`
