### PR TITLE
fix(ui): refine project units and scheduler overview layout

### DIFF
--- a/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
+++ b/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
@@ -31,7 +31,8 @@
             <div class="project-units-monitor-grid">
             <MudDataGrid T="DtoProjectUnit" Items="@_projectUnits" Filterable="true"
                         SortMode="SortMode.Multiple" Groupable="true" GroupExpanded="false"
-                        Dense="true" Hover="true" ReadOnly="true">
+                        Dense="true" Hover="true" ReadOnly="true"
+                        RowsPerPage="@DEFAULT_PAGE_SIZE">
                 <Columns>
                     <PropertyColumn T="DtoProjectUnit" TProperty="string" Property="x => x.Title" Title="@L["ProjectUnitMonitor:Columns:Name"]"
                                     HeaderClass="project-units-monitor-grid__name-column"
@@ -94,6 +95,9 @@
                         </CellTemplate>
                     </TemplateColumn>
                 </Columns>
+                <PagerContent>
+                    <MudDataGridPager T="DtoProjectUnit" PageSizeOptions="@PageSizeOptions" />
+                </PagerContent>
             </MudDataGrid>
             </div>
         }
@@ -111,6 +115,9 @@
                          AllProjectUnits="_projectUnits" />
 
 @code {
+    private const int DEFAULT_PAGE_SIZE = 50;
+    private static readonly int[] PageSizeOptions = [25, 50, 100, 200];
+
     private List<DtoProjectUnit> _projectUnits = [];
     private bool _loading;
     private bool _detailDialogVisible;

--- a/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
+++ b/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor
@@ -96,7 +96,7 @@
                     </TemplateColumn>
                 </Columns>
                 <PagerContent>
-                    <MudDataGridPager T="DtoProjectUnit" PageSizeOptions="@PageSizeOptions" />
+                    <MudDataGridPager T="DtoProjectUnit" PageSizeOptions="@PAGE_SIZE_OPTIONS" />
                 </PagerContent>
             </MudDataGrid>
             </div>
@@ -116,7 +116,7 @@
 
 @code {
     private const int DEFAULT_PAGE_SIZE = 50;
-    private static readonly int[] PageSizeOptions = [25, 50, 100, 200];
+    private static readonly int[] PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 
     private List<DtoProjectUnit> _projectUnits = [];
     private bool _loading;

--- a/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor.css
+++ b/Monica.Framework.UI/UIProjectUnits/Components/ProjectUnitMonitor.razor.css
@@ -70,11 +70,10 @@
         overflow: hidden;
     }
 
-    .project-units-monitor-grid ::deep .project-units-monitor-grid__type-column,
-    .project-units-monitor-grid ::deep .project-units-monitor-grid__count-column,
     .project-units-monitor-grid ::deep .project-units-monitor-grid__actions-column {
         justify-content: center;
     }
+
 }
 
 .project-units-monitor-grid__ellipsis {

--- a/Monica.JobScheduler.UI/Pages/DashboardPage.razor
+++ b/Monica.JobScheduler.UI/Pages/DashboardPage.razor
@@ -44,20 +44,17 @@
                               TimeWindowText="@GetTimeWindowText()" />
 
         @* Main Content Grid *@
-        <MudGrid Spacing="3">
-            @* State Distribution *@
-            <MudItem xs="12">
-                <JobStateDistributionChart StateDistribution="_summary.StateDistribution"
-                                           TimeWindowText="@GetTimeWindowText()" />
+        <MudGrid Spacing="3" Class="dashboard-overview-grid">
+            <MudItem xs="12" md="6" Class="dashboard-overview-column">
+                <div class="dashboard-left-stack">
+                    <JobStateDistributionChart StateDistribution="_summary.StateDistribution"
+                                               TimeWindowText="@GetTimeWindowText()" />
+
+                    <ProblemJobsPanel Problems="_problemJobs" />
+                </div>
             </MudItem>
 
-            @* Problem Jobs *@
-            <MudItem xs="12" md="6" Class="dashboard-equal-card">
-                <ProblemJobsPanel Problems="_problemJobs" />
-            </MudItem>
-
-            @* Right Column: Recent Activity Timeline *@
-            <MudItem xs="12" md="6" Class="dashboard-equal-card">
+            <MudItem xs="12" md="6" Class="dashboard-overview-column dashboard-activity-column">
                 <RecentActivityTimeline Activities="_recentActivities" />
             </MudItem>
         </MudGrid>

--- a/Monica.JobScheduler.UI/Pages/DashboardPage.razor.css
+++ b/Monica.JobScheduler.UI/Pages/DashboardPage.razor.css
@@ -33,13 +33,29 @@
     animation: rotate 1s linear infinite;
 }
 
-.dashboard-page ::deep .dashboard-equal-card {
+.dashboard-page ::deep .dashboard-overview-grid {
+    align-items: stretch;
+}
+
+.dashboard-page ::deep .dashboard-overview-column {
     display: flex;
     min-width: 0;
 }
 
-.dashboard-page ::deep .dashboard-equal-card > * {
+.dashboard-page ::deep .dashboard-overview-column > * {
     width: 100%;
+}
+
+.dashboard-left-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    height: 100%;
+    min-width: 0;
+}
+
+.dashboard-activity-column ::deep .activity-timeline-wrapper {
+    height: 100%;
 }
 
 @keyframes rotate {


### PR DESCRIPTION
## Summary
- Add pagination to the Project Units list with a default page size of 50
- Refine Project Units table alignment so type/dependency badges align left while actions stay centered
- Update Job Scheduler dashboard overview layout with Status Distribution and Needs Attention stacked on the left, and Recent Activity stretched on the right

## Verification
- dotnet build Monica.Framework.UI/Monica.Framework.UI.csproj --no-restore
- dotnet build /root/Monica.Docs/src/AppHost/Monica.Docs.Api/Monica.Docs.Api.csproj --no-restore
- git diff --check

## Acceptance
- Reviewed via Monica.Docs bridge preview at http://100.114.135.51:5298/project-units and http://100.114.135.51:5298/job-scheduler/dashboard
- User accepted the preview before PR creation