### PR TITLE
docs: add minimal job scheduler ui example

### DIFF
--- a/Monica.slnx
+++ b/Monica.slnx
@@ -4,6 +4,9 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Folder Name="/examples/">
+    <Project Path="examples/JobSchedulerMinimal/JobSchedulerMinimal.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Test.Monica.Core/Test.Monica.Core.csproj" />
     <Project Path="tests/Test.Monica.JobScheduler.UI/Test.Monica.JobScheduler.UI.csproj" />

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ public sealed class HeartbeatJob(ILogger<HeartbeatJob> logger) : RecurringJob
 ```
 
 - Recurring and triggered jobs share one scheduling model.
-- The dashboard lives at `/job-scheduler`.
 - Concurrency guards, zombie detection, and persistence options are built in.
-- Add `Mo.AddJobSchedulerUI()` when you want the browser dashboard and job detail views.
+- Add `Mo.AddJobSchedulerUI()` when you want the browser dashboard and job detail views. The UI requires an ASP.NET Core web host because it serves Blazor routes and static web assets; a plain console host is enough for scheduler-only jobs, but not for the dashboard.
+- See [`examples/JobSchedulerMinimal`](examples/JobSchedulerMinimal) for the smallest verified ASP.NET Core host that runs JobScheduler + JobScheduler UI at `/job-scheduler`.
 
 ## Dashboards, Themes, and i18n
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -74,9 +74,9 @@ public sealed class HeartbeatJob(ILogger<HeartbeatJob> logger) : RecurringJob
 ```
 
 - 定时作业和触发式作业使用同一套调度模型。
-- 仪表板地址是 `/job-scheduler`。
 - 并发控制、僵尸检测和持久化选项都已内置。
-- 需要浏览器运维界面时，再补上 `Mo.AddJobSchedulerUI()`。
+- 需要浏览器运维界面时，再补上 `Mo.AddJobSchedulerUI()`。UI 需要 ASP.NET Core Web 宿主来提供 Blazor 路由和静态资源；普通 Console 宿主适合只跑调度任务，但不能承载仪表板。
+- 最小可运行参考见 [`examples/JobSchedulerMinimal`](examples/JobSchedulerMinimal)，它演示了如何用最少 ASP.NET Core 宿主在 `/job-scheduler` 跑起 JobScheduler + JobScheduler UI。
 
 ## 仪表板、主题与国际化
 

--- a/examples/JobSchedulerMinimal/JobSchedulerMinimal.csproj
+++ b/examples/JobSchedulerMinimal/JobSchedulerMinimal.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <RequiresAspNetWebAssets>true</RequiresAspNetWebAssets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Monica.JobScheduler.UI\Monica.JobScheduler.UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/JobSchedulerMinimal/Program.cs
+++ b/examples/JobSchedulerMinimal/Program.cs
@@ -1,0 +1,40 @@
+using Monica.Core;
+using Monica.Core.Modularity.Extensions;
+using Monica.JobScheduler.Abstractions;
+using Monica.JobScheduler.Annotations;
+using Monica.Modules;
+
+var builder = WebApplication.CreateBuilder(args);
+
+Mo.AddJobScheduler()
+    .UseInMemoryMetadataRepository()
+    .UseSchedulerScope("job-scheduler-minimal")
+    .UseInMemoryProvider();
+Mo.AddJobSchedulerUI();
+
+builder.UseMonica();
+
+var app = builder.Build();
+
+app.UseMonica();
+app.MapGet("/", () => Results.Redirect("/job-scheduler"));
+app.MapMonica();
+
+app.Run();
+
+/// <summary>
+/// Recurring example job that gives the JobScheduler dashboard a visible execution history.
+/// </summary>
+[JobConfig(
+    JobName = "Minimal heartbeat",
+    Description = "Writes a log entry every 30 seconds so the dashboard has a recurring job to display.",
+    CronSchedule = "*/30 * * * * *")]
+public sealed class MinimalHeartbeatJob(ILogger<MinimalHeartbeatJob> logger) : RecurringJob
+{
+    /// <inheritdoc />
+    public override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Minimal heartbeat job ran at {Time:O}.", DateTimeOffset.Now);
+        return Task.CompletedTask;
+    }
+}

--- a/examples/JobSchedulerMinimal/Properties/launchSettings.json
+++ b/examples/JobSchedulerMinimal/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "JobSchedulerMinimal": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://127.0.0.1:5298",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/examples/JobSchedulerMinimal/README.md
+++ b/examples/JobSchedulerMinimal/README.md
@@ -1,0 +1,21 @@
+# JobScheduler Minimal
+
+Minimal ASP.NET Core host for Monica JobScheduler plus the JobScheduler UI.
+
+## Run
+
+```bash
+dotnet run --project examples/JobSchedulerMinimal/JobSchedulerMinimal.csproj
+```
+
+Open <http://127.0.0.1:5298/job-scheduler>.
+
+The launch profile uses the `Development` environment so Blazor static web assets from the referenced UI modules are available during `dotnet run`.
+
+## What It Registers
+
+- `Mo.AddJobScheduler().UseInMemoryMetadataRepository().UseSchedulerScope("job-scheduler-minimal").UseInMemoryProvider()`
+- `Mo.AddJobSchedulerUI()`
+- Monica host lifecycle: `builder.UseMonica()`, `app.UseMonica()`, and `app.MapMonica()`
+
+The app defines one recurring `MinimalHeartbeatJob` so the dashboard and job definitions page have a concrete job to display.

--- a/examples/JobSchedulerMinimal/appsettings.Development.json
+++ b/examples/JobSchedulerMinimal/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/examples/JobSchedulerMinimal/appsettings.json
+++ b/examples/JobSchedulerMinimal/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `examples/JobSchedulerMinimal`, a minimal ASP.NET Core host for JobScheduler + JobScheduler UI
- document the README distinction between scheduler-only console hosts and UI-required ASP.NET Core hosts
- point README readers to the verified minimal example

## Verification
- `dotnet build examples/JobSchedulerMinimal/JobSchedulerMinimal.csproj -m`
- Playwright opened `http://127.0.0.1:5298/job-scheduler`
- Saved verification screenshot locally at `.task-plans/job-scheduler-minimal-example/job-scheduler-final.png`
