### PR TITLE
新增 `Monica.EventBus.Kafka` 模块，提供 Kafka EventBus 集成与管理控制台能力

### DIFF
--- a/Monica.Core/Modularity/Models/BuiltInModuleKey.cs
+++ b/Monica.Core/Modularity/Models/BuiltInModuleKey.cs
@@ -18,6 +18,18 @@ public enum BuiltInModuleKey
     /// Optional EventBus bridge module for distributed configuration reload notifications.
     /// </summary>
     ConfigurationEventBus,
+    /// <summary>
+    /// Kafka provider and management console module for EventBus integrations.
+    /// </summary>
+    EventBusKafka,
+    /// <summary>
+    /// Kafka provider management console UI module for EventBus integrations.
+    /// </summary>
+    EventBusKafkaUI,
+    /// <summary>
+    /// Kafka management console EF Core persistence module.
+    /// </summary>
+    EventBusKafkaEfCore,
     Authentication,
     ConfigurationCenter,
     ServiceDiscovery,

--- a/Monica.EventBus.Kafka/Abstractions/IKafkaAdminProvider.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaAdminProvider.cs
@@ -1,0 +1,76 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Abstractions;
+
+/// <summary>
+/// Executes direct Kafka broker operations used by the Kafka console.
+/// </summary>
+/// <remarks>
+/// Implementations should throw provider-specific exceptions for failed broker operations. Facades
+/// are responsible for converting those exceptions to Monica result envelopes.
+/// </remarks>
+public interface IKafkaAdminProvider
+{
+    /// <summary>
+    /// Tests whether the target cluster can be reached.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task TestConnectionAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists brokers known by the target cluster metadata.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Broker metadata.</returns>
+    Task<IReadOnlyList<KafkaBrokerInfo>> ListBrokersAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists topics in the target cluster.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Topic summaries.</returns>
+    Task<IReadOnlyList<KafkaTopicSummary>> ListTopicsAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a topic.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="request">Topic creation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CreateTopicAsync(KafkaClusterConfig cluster, KafkaTopicCreateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a topic.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="topicName">Topic name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteTopicAsync(KafkaClusterConfig cluster, string topicName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Increases a topic's partition count.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="request">Partition update request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task IncreasePartitionsAsync(KafkaClusterConfig cluster, KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates a topic's retention time.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="request">Retention update request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateRetentionAsync(KafkaClusterConfig cluster, KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists consumer groups in the target cluster.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Consumer group summaries.</returns>
+    Task<IReadOnlyList<KafkaConsumerGroupSummary>> ListConsumerGroupsAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+}

--- a/Monica.EventBus.Kafka/Abstractions/IKafkaClusterConfigProvider.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaClusterConfigProvider.cs
@@ -1,0 +1,16 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Abstractions;
+
+/// <summary>
+/// Resolves the default Kafka cluster used by the native Kafka EventBus provider.
+/// </summary>
+public interface IKafkaClusterConfigProvider
+{
+    /// <summary>
+    /// Gets the direct EventBus cluster configuration.
+    /// </summary>
+    /// <returns>The direct Kafka cluster configuration.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no direct Kafka cluster is configured.</exception>
+    KafkaClusterConfig GetDirectEventBusCluster();
+}

--- a/Monica.EventBus.Kafka/Abstractions/IKafkaConsoleRepository.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaConsoleRepository.cs
@@ -1,0 +1,77 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Abstractions;
+
+/// <summary>
+/// Stores Kafka console cluster configuration and sampled performance snapshots.
+/// </summary>
+/// <remarks>
+/// Implementations must be safe for concurrent reads and writes because UI requests and hosted
+/// samplers can access the repository at the same time. Implementations should not throw when a
+/// delete targets a missing cluster.
+/// </remarks>
+public interface IKafkaConsoleRepository
+{
+    /// <summary>
+    /// Gets all configured Kafka clusters.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Configured clusters.</returns>
+    Task<IReadOnlyList<KafkaClusterConfig>> GetClustersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets one configured Kafka cluster.
+    /// </summary>
+    /// <param name="clusterId">Cluster identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cluster when found; otherwise <see langword="null"/>.</returns>
+    Task<KafkaClusterConfig?> GetClusterAsync(string clusterId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or updates one configured Kafka cluster.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes one configured Kafka cluster and any cluster-owned sampled snapshots.
+    /// </summary>
+    /// <param name="clusterId">Cluster identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves a sampled performance snapshot.
+    /// </summary>
+    /// <param name="snapshot">Snapshot to save.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SavePerformanceSnapshotAsync(KafkaPerformanceSnapshot snapshot, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the latest sampled performance snapshot for one cluster.
+    /// </summary>
+    /// <param name="clusterId">Cluster identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The latest snapshot when found; otherwise <see langword="null"/>.</returns>
+    Task<KafkaPerformanceSnapshot?> GetLatestPerformanceSnapshotAsync(string clusterId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets recent sampled performance snapshots for one cluster.
+    /// </summary>
+    /// <param name="clusterId">Cluster identifier.</param>
+    /// <param name="limit">Maximum number of snapshots to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Snapshots ordered from oldest to newest.</returns>
+    Task<IReadOnlyList<KafkaPerformanceSnapshot>> GetPerformanceSnapshotsAsync(
+        string clusterId,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes sampled performance snapshots older than the specified timestamp.
+    /// </summary>
+    /// <param name="olderThanUtc">Exclusive UTC cutoff.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeletePerformanceSnapshotsOlderThanAsync(DateTimeOffset olderThanUtc, CancellationToken cancellationToken = default);
+}

--- a/Monica.EventBus.Kafka/Abstractions/IKafkaMessageReader.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaMessageReader.cs
@@ -1,0 +1,26 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Abstractions;
+
+/// <summary>
+/// Reads bounded Kafka message previews for console inspection.
+/// </summary>
+/// <remarks>
+/// Implementations must not commit offsets or otherwise mutate application consumer state.
+/// Message previews are diagnostic data and should be bounded by module limits to avoid loading
+/// large payloads into the UI.
+/// </remarks>
+public interface IKafkaMessageReader
+{
+    /// <summary>
+    /// Reads a bounded sample of recent messages from a topic.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="request">Message preview request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Topic message sample.</returns>
+    Task<KafkaTopicMessageBatch> ReadMessagesAsync(
+        KafkaClusterConfig cluster,
+        KafkaTopicMessagesRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/Monica.EventBus.Kafka/Abstractions/IKafkaPerformanceMetricsProvider.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaPerformanceMetricsProvider.cs
@@ -1,0 +1,27 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Abstractions;
+
+/// <summary>
+/// Captures Kafka offset totals used by the console to estimate message rates.
+/// </summary>
+/// <remarks>
+/// Implementations should use read-only Kafka admin APIs and must not commit offsets or alter
+/// consumer group state.
+/// </remarks>
+public interface IKafkaPerformanceMetricsProvider
+{
+    /// <summary>
+    /// Captures current Kafka offset totals for visible non-internal topics and consumer groups.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="topics">Topic summaries from the same sampling cycle.</param>
+    /// <param name="consumerGroups">Consumer group summaries from the same sampling cycle.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Offset totals for rate calculation.</returns>
+    Task<KafkaPerformanceOffsetTotals> CaptureOffsetTotalsAsync(
+        KafkaClusterConfig cluster,
+        IReadOnlyList<KafkaTopicSummary> topics,
+        IReadOnlyList<KafkaConsumerGroupSummary> consumerGroups,
+        CancellationToken cancellationToken = default);
+}

--- a/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
+++ b/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
@@ -105,6 +105,14 @@ public sealed class KafkaConsoleFacade(
     }
 
     /// <summary>
+    /// Reads a bounded sample of recent messages from a topic.
+    /// </summary>
+    public Task<Res<KafkaTopicMessageBatch>> ReadTopicMessagesAsync(KafkaTopicMessagesRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.ReadMessagesAsync(request, cancellationToken), "Failed to read Kafka topic messages");
+    }
+
+    /// <summary>
     /// Lists consumer groups.
     /// </summary>
     public Task<Res<IReadOnlyList<KafkaConsumerGroupSummary>>> ListConsumerGroupsAsync(string clusterId, CancellationToken cancellationToken = default)

--- a/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
+++ b/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
@@ -1,0 +1,158 @@
+using Monica.Core.Extensions;
+using Monica.Core.Results;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Services;
+
+namespace Monica.EventBus.Kafka.Facades;
+
+/// <summary>
+/// Host-facing Kafka console entry point used by Minimal APIs and Blazor UI.
+/// </summary>
+public sealed class KafkaConsoleFacade(
+    KafkaIntegrationService integrationService,
+    KafkaClusterService clusterService,
+    KafkaDashboardService dashboardService,
+    KafkaTopicService topicService,
+    KafkaConsumerGroupService consumerGroupService,
+    KafkaPerformanceService performanceService)
+{
+    /// <summary>
+    /// Gets the current Kafka EventBus integration state.
+    /// </summary>
+    public Task<Res<KafkaIntegrationSnapshot>> GetIntegrationAsync(CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => integrationService.GetSnapshotAsync(cancellationToken), "Failed to load Kafka integration state");
+    }
+
+    /// <summary>
+    /// Gets Kafka clusters visible to the console.
+    /// </summary>
+    public Task<Res<IReadOnlyList<KafkaClusterSummary>>> ListClustersAsync(CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => clusterService.ListClustersAsync(cancellationToken), "Failed to load Kafka clusters");
+    }
+
+    /// <summary>
+    /// Creates or updates a Kafka cluster.
+    /// </summary>
+    public Task<Res<KafkaClusterSummary>> UpsertClusterAsync(KafkaClusterUpsertRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => clusterService.UpsertClusterAsync(request.Cluster, cancellationToken), "Failed to save Kafka cluster");
+    }
+
+    /// <summary>
+    /// Deletes a Kafka cluster saved through the console.
+    /// </summary>
+    public Task<Res> DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => clusterService.DeleteClusterAsync(clusterId, cancellationToken), "Kafka cluster deleted", "Failed to delete Kafka cluster");
+    }
+
+    /// <summary>
+    /// Tests direct Kafka connectivity for a cluster.
+    /// </summary>
+    public Task<Res<KafkaClusterSummary>> TestClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => clusterService.TestConnectionAsync(clusterId, cancellationToken), "Failed to test Kafka cluster");
+    }
+
+    /// <summary>
+    /// Gets a dashboard aggregate.
+    /// </summary>
+    public Task<Res<KafkaDashboardSnapshot>> GetDashboardAsync(string? clusterId = null, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => dashboardService.GetDashboardAsync(clusterId, cancellationToken), "Failed to load Kafka dashboard");
+    }
+
+    /// <summary>
+    /// Lists topics in a cluster.
+    /// </summary>
+    public Task<Res<IReadOnlyList<KafkaTopicSummary>>> ListTopicsAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.ListTopicsAsync(clusterId, cancellationToken), "Failed to load Kafka topics");
+    }
+
+    /// <summary>
+    /// Creates a topic.
+    /// </summary>
+    public Task<Res> CreateTopicAsync(KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.CreateTopicAsync(request, cancellationToken), "Kafka topic created", "Failed to create Kafka topic");
+    }
+
+    /// <summary>
+    /// Deletes a topic.
+    /// </summary>
+    public Task<Res> DeleteTopicAsync(string clusterId, string topicName, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.DeleteTopicAsync(clusterId, topicName, cancellationToken), "Kafka topic deleted", "Failed to delete Kafka topic");
+    }
+
+    /// <summary>
+    /// Increases the partition count for a topic.
+    /// </summary>
+    public Task<Res> IncreasePartitionsAsync(KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.IncreasePartitionsAsync(request, cancellationToken), "Kafka topic partitions updated", "Failed to update Kafka partitions");
+    }
+
+    /// <summary>
+    /// Updates topic retention.
+    /// </summary>
+    public Task<Res> UpdateRetentionAsync(KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => topicService.UpdateRetentionAsync(request, cancellationToken), "Kafka topic retention updated", "Failed to update Kafka retention");
+    }
+
+    /// <summary>
+    /// Lists consumer groups.
+    /// </summary>
+    public Task<Res<IReadOnlyList<KafkaConsumerGroupSummary>>> ListConsumerGroupsAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => consumerGroupService.ListConsumerGroupsAsync(clusterId, cancellationToken), "Failed to load Kafka consumer groups");
+    }
+
+    /// <summary>
+    /// Gets recent performance snapshots.
+    /// </summary>
+    public Task<Res<IReadOnlyList<KafkaPerformanceSnapshot>>> GetPerformanceHistoryAsync(
+        string clusterId,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => performanceService.GetHistoryAsync(clusterId, limit, cancellationToken), "Failed to load Kafka performance history");
+    }
+
+    /// <summary>
+    /// Captures a fresh performance snapshot.
+    /// </summary>
+    public Task<Res<KafkaPerformanceSnapshot>> CapturePerformanceAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(() => performanceService.CaptureAsync(clusterId, cancellationToken), "Failed to capture Kafka performance snapshot");
+    }
+
+    private static async Task<Res<T>> ExecuteAsync<T>(Func<Task<T>> action, string failurePrefix)
+    {
+        try
+        {
+            return Res.Ok(await action());
+        }
+        catch (Exception ex)
+        {
+            return Res.Fail($"{failurePrefix}: {ex.GetMessageRecursively()}");
+        }
+    }
+
+    private static async Task<Res> ExecuteAsync(Func<Task> action, string successMessage, string failurePrefix)
+    {
+        try
+        {
+            await action();
+            return Res.Ok(successMessage);
+        }
+        catch (Exception ex)
+        {
+            return Res.Fail($"{failurePrefix}: {ex.GetMessageRecursively()}");
+        }
+    }
+}

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource.cs
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource.cs
@@ -1,0 +1,11 @@
+using Monica.Core.Localization;
+using Monica.Core.Localization.Abstractions;
+
+namespace Monica.EventBus.Kafka.Localization;
+
+/// <summary>
+/// Marker class for Kafka EventBus console localization resources.
+/// </summary>
+public sealed class EventBusKafkaResource : ILocalizationResource
+{
+}

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
@@ -113,7 +113,11 @@
       "Topics": "Topics",
       "TopicsHint": "Visible through Kafka metadata",
       "ConsumerGroups": "Consumer groups",
-      "ConsumerGroupsHint": "Described from Kafka admin APIs"
+      "ConsumerGroupsHint": "Described from Kafka admin APIs",
+      "WriteRate": "Write rate",
+      "WriteRateHint": "Latest offset growth",
+      "ConsumeRate": "Consume rate",
+      "ConsumeRateHint": "Latest committed offset growth"
     },
     "Modes": {
       "DirectKafka": "Direct Kafka",
@@ -281,11 +285,15 @@
       "Brokers": "Brokers",
       "Topics": "Topics",
       "Groups": "Groups",
+      "WriteRate": "Write rate",
+      "ConsumeRate": "Consume rate",
       "Lag": "Lag",
       "Message": "Message"
     },
     "Values": {
       "LagUnknown": "Unknown",
+      "RateUnknown": "Unknown",
+      "RatePerSecond": "{0} msg/s",
       "NoMessage": "OK"
     },
     "Messages": {

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
@@ -1,0 +1,273 @@
+{
+  "Api": {
+    "Integration": {
+      "Get": {
+        "Summary": "Gets Kafka EventBus integration state",
+        "Description": "Returns the active EventBus provider and Kafka integration visibility state."
+      }
+    },
+    "Clusters": {
+      "List": {
+        "Summary": "Lists Kafka clusters",
+        "Description": "Lists Kafka clusters configured through module options or the console."
+      },
+      "Upsert": {
+        "Summary": "Creates or updates a Kafka cluster",
+        "Description": "Saves a Kafka cluster configuration for console visibility and admin operations."
+      },
+      "Delete": {
+        "Summary": "Deletes a Kafka cluster",
+        "Description": "Deletes a console-managed Kafka cluster and its sampled snapshots."
+      },
+      "Test": {
+        "Summary": "Tests Kafka cluster connectivity",
+        "Description": "Runs a direct broker metadata probe for a Kafka cluster."
+      }
+    },
+    "Dashboard": {
+      "Get": {
+        "Summary": "Gets Kafka dashboard data",
+        "Description": "Returns the selected Kafka cluster dashboard aggregate."
+      }
+    },
+    "Topics": {
+      "List": {
+        "Summary": "Lists Kafka topics",
+        "Description": "Lists topics for a Kafka cluster."
+      },
+      "Create": {
+        "Summary": "Creates a Kafka topic",
+        "Description": "Creates a topic through direct Kafka admin access."
+      },
+      "Delete": {
+        "Summary": "Deletes a Kafka topic",
+        "Description": "Deletes a topic through direct Kafka admin access."
+      },
+      "Partitions": {
+        "Summary": "Increases Kafka topic partitions",
+        "Description": "Increases a topic's partition count."
+      },
+      "Retention": {
+        "Summary": "Updates Kafka topic retention",
+        "Description": "Updates a topic's retention.ms configuration."
+      }
+    },
+    "ConsumerGroups": {
+      "List": {
+        "Summary": "Lists Kafka consumer groups",
+        "Description": "Lists consumer groups visible to direct Kafka admin access."
+      }
+    },
+    "Performance": {
+      "History": {
+        "Summary": "Gets Kafka performance history",
+        "Description": "Returns recent Kafka performance snapshots for a cluster."
+      },
+      "Capture": {
+        "Summary": "Captures Kafka performance",
+        "Description": "Captures a broker, topic, and consumer group snapshot."
+      }
+    }
+  },
+  "Common": {
+    "Actions": {
+      "Cancel": "Cancel",
+      "Delete": "Delete",
+      "Edit": "Edit",
+      "Refresh": "Refresh",
+      "Save": "Save",
+      "Select": "Select"
+    }
+  },
+  "Page": {
+    "PageTitle": "Kafka EventBus",
+    "Eyebrow": "EventBus integration",
+    "Title": "Kafka EventBus Console",
+    "Subtitle": "Inspect Kafka-backed EventBus integrations, clusters, topics, consumer groups, and performance snapshots.",
+    "States": {
+      "Loading": "Loading Kafka console",
+      "LoadingDescription": "Resolving EventBus provider state and configured Kafka clusters."
+    },
+    "Messages": {
+      "OperationFailed": "Operation failed.",
+      "RefreshSucceeded": "Kafka console refreshed."
+    }
+  },
+  "Tabs": {
+    "Dashboard": "Dashboard",
+    "Clusters": "Clusters",
+    "Topics": "Topics",
+    "ConsumerGroups": "Consumer Groups",
+    "Performance": "Performance"
+  },
+  "Dashboard": {
+    "Cards": {
+      "Provider": "Active provider",
+      "Brokers": "Brokers",
+      "BrokersHint": "From latest direct metadata or snapshot",
+      "Topics": "Topics",
+      "TopicsHint": "Visible through Kafka metadata",
+      "ConsumerGroups": "Consumer groups",
+      "ConsumerGroupsHint": "Described from Kafka admin APIs"
+    },
+    "Modes": {
+      "DirectKafka": "Direct Kafka",
+      "DaprKafka": "Dapr-backed Kafka",
+      "DaprNonKafka": "Dapr without Kafka metadata",
+      "NotConfigured": "Not configured",
+      "Unknown": "Unknown"
+    },
+    "SelectedCluster": {
+      "None": "No cluster selected",
+      "NoneDescription": "Create or configure a Kafka cluster to enable console views.",
+      "ExternalCredentials": "Kafka credentials are managed outside Monica."
+    }
+  },
+  "Clusters": {
+    "Title": "Kafka clusters",
+    "Empty": "No Kafka clusters are visible. Create a cluster or declare one through module configuration.",
+    "Actions": {
+      "New": "New cluster",
+      "Test": "Test connection"
+    },
+    "Columns": {
+      "Name": "Name",
+      "Bootstrap": "Bootstrap",
+      "Mode": "Mode",
+      "Status": "Status",
+      "Actions": "Actions"
+    },
+    "Values": {
+      "ExternalBootstrap": "Managed externally"
+    },
+    "Modes": {
+      "DaprBacked": "Dapr-backed",
+      "Direct": "Direct"
+    },
+    "Status": {
+      "Reachable": "Reachable",
+      "Unknown": "Not tested",
+      "Limited": "Limited"
+    },
+    "Dialog": {
+      "CreateTitle": "New Kafka cluster",
+      "EditTitle": "Edit Kafka cluster"
+    },
+    "Confirm": {
+      "DeleteTitle": "Delete Kafka cluster",
+      "DeleteMessage": "Delete cluster {0} and its sampled snapshots?"
+    },
+    "Messages": {
+      "Saved": "Kafka cluster saved.",
+      "Deleted": "Kafka cluster deleted.",
+      "TestSucceeded": "Kafka cluster is reachable."
+    },
+    "Fields": {
+      "DisplayName": "Display name",
+      "ClusterId": "Cluster id",
+      "BootstrapServers": "Bootstrap servers",
+      "ClientId": "Client id",
+      "JmxEndpoint": "JMX endpoint",
+      "SecurityProtocol": "Security protocol",
+      "SaslMechanism": "SASL mechanism",
+      "SaslUsername": "SASL username",
+      "SaslPassword": "SASL password",
+      "SslCaLocation": "SSL CA location",
+      "IsDaprBacked": "Backs Dapr pub/sub",
+      "CredentialsManagedExternally": "Credentials managed externally",
+      "DaprPubSubName": "Dapr pub/sub name"
+    },
+    "Validation": {
+      "DisplayNameRequired": "Display name is required.",
+      "BootstrapRequired": "Bootstrap servers are required when credentials are managed by Monica."
+    }
+  },
+  "Topics": {
+    "Title": "Topics",
+    "Unavailable": "Topic management requires direct Kafka broker access.",
+    "Empty": "No topics were returned for the selected cluster.",
+    "Actions": {
+      "Create": "Create topic",
+      "Partitions": "Increase partitions",
+      "Retention": "Set retention"
+    },
+    "Columns": {
+      "Name": "Name",
+      "Partitions": "Partitions",
+      "Replication": "Replication",
+      "Retention": "Retention",
+      "Actions": "Actions"
+    },
+    "Values": {
+      "Internal": "Internal topic",
+      "RetentionUnknown": "Unknown",
+      "RetentionMs": "{0} ms"
+    },
+    "Dialog": {
+      "CreateTitle": "Create Kafka topic",
+      "PartitionsTitle": "Increase partitions",
+      "RetentionTitle": "Set retention",
+      "PartitionsMessage": "Topic {0} currently has {1} partitions. Kafka only allows increasing this value.",
+      "RetentionMessage": "Set retention.ms for topic {0}."
+    },
+    "Confirm": {
+      "DeleteTitle": "Delete Kafka topic",
+      "DeleteMessage": "Delete topic {0}?"
+    },
+    "Messages": {
+      "Created": "Kafka topic created.",
+      "Deleted": "Kafka topic deleted.",
+      "PartitionsUpdated": "Kafka topic partitions updated.",
+      "RetentionUpdated": "Kafka topic retention updated."
+    },
+    "Fields": {
+      "TopicName": "Topic name",
+      "Partitions": "Partitions",
+      "ReplicationFactor": "Replication factor",
+      "RetentionMs": "Retention ms",
+      "IncreaseTo": "Increase to"
+    },
+    "Validation": {
+      "NameRequired": "Topic name is required.",
+      "PartitionIncreaseRequired": "The new partition count must be greater than the current partition count.",
+      "RetentionRequired": "Retention must be greater than zero."
+    }
+  },
+  "ConsumerGroups": {
+    "Title": "Consumer groups",
+    "Unavailable": "Consumer group inspection requires direct Kafka broker access.",
+    "Empty": "No consumer groups were returned for the selected cluster.",
+    "Columns": {
+      "GroupId": "Group id",
+      "State": "State",
+      "Members": "Members",
+      "Lag": "Lag"
+    },
+    "Values": {
+      "LagUnknown": "Unknown"
+    }
+  },
+  "Performance": {
+    "Title": "Performance snapshots",
+    "Unavailable": "Performance sampling requires direct Kafka broker access.",
+    "Empty": "No performance snapshots have been captured.",
+    "Actions": {
+      "Capture": "Capture"
+    },
+    "Columns": {
+      "CapturedAt": "Captured at",
+      "Brokers": "Brokers",
+      "Topics": "Topics",
+      "Groups": "Groups",
+      "Lag": "Lag",
+      "Message": "Message"
+    },
+    "Values": {
+      "LagUnknown": "Unknown",
+      "NoMessage": "OK"
+    },
+    "Messages": {
+      "Captured": "Kafka performance snapshot captured."
+    }
+  }
+}

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/en-US.json
@@ -50,6 +50,10 @@
       "Retention": {
         "Summary": "Updates Kafka topic retention",
         "Description": "Updates a topic's retention.ms configuration."
+      },
+      "Messages": {
+        "Summary": "Reads Kafka topic messages",
+        "Description": "Reads a bounded recent message preview without committing consumer offsets."
       }
     },
     "ConsumerGroups": {
@@ -72,6 +76,7 @@
   "Common": {
     "Actions": {
       "Cancel": "Cancel",
+      "Close": "Close",
       "Delete": "Delete",
       "Edit": "Edit",
       "Refresh": "Refresh",
@@ -188,6 +193,7 @@
     "Empty": "No topics were returned for the selected cluster.",
     "Actions": {
       "Create": "Create topic",
+      "Messages": "View messages",
       "Partitions": "Increase partitions",
       "Retention": "Set retention"
     },
@@ -200,15 +206,31 @@
     },
     "Values": {
       "Internal": "Internal topic",
+      "NoKey": "No key",
+      "EmptyValue": "Empty value",
+      "Tombstone": "Tombstone message",
+      "TombstoneEncoding": "Null value",
+      "TimestampUnknown": "Timestamp unavailable",
       "RetentionUnknown": "Unknown",
       "RetentionMs": "{0} ms"
     },
     "Dialog": {
       "CreateTitle": "Create Kafka topic",
+      "MessagesTitle": "Messages in {0}",
       "PartitionsTitle": "Increase partitions",
       "RetentionTitle": "Set retention",
       "PartitionsMessage": "Topic {0} currently has {1} partitions. Kafka only allows increasing this value.",
       "RetentionMessage": "Set retention.ms for topic {0}."
+    },
+    "MessagesDialog": {
+      "ReadHint": "Showing up to {0} recent messages sampled at {1}. This preview does not commit consumer offsets.",
+      "Empty": "No messages were found near the end of this topic.",
+      "OffsetFormat": "Partition {0}, offset {1}",
+      "Key": "Key",
+      "Encoding": "Encoding",
+      "Size": "Size",
+      "SizeBytes": "{0} bytes",
+      "Truncated": "The payload was truncated for display."
     },
     "Confirm": {
       "DeleteTitle": "Delete Kafka topic",

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
@@ -50,6 +50,10 @@
       "Retention": {
         "Summary": "更新 Kafka 主题保留时间",
         "Description": "更新主题的 retention.ms 配置。"
+      },
+      "Messages": {
+        "Summary": "读取 Kafka 主题消息",
+        "Description": "读取有限数量的最近消息预览，不提交消费者 offset。"
       }
     },
     "ConsumerGroups": {
@@ -72,6 +76,7 @@
   "Common": {
     "Actions": {
       "Cancel": "取消",
+      "Close": "关闭",
       "Delete": "删除",
       "Edit": "编辑",
       "Refresh": "刷新",
@@ -188,6 +193,7 @@
     "Empty": "选中集群未返回主题。",
     "Actions": {
       "Create": "创建主题",
+      "Messages": "查看消息",
       "Partitions": "增加分区",
       "Retention": "设置保留时间"
     },
@@ -200,15 +206,31 @@
     },
     "Values": {
       "Internal": "内部主题",
+      "NoKey": "无 Key",
+      "EmptyValue": "空值",
+      "Tombstone": "Tombstone 消息",
+      "TombstoneEncoding": "Null 值",
+      "TimestampUnknown": "时间戳不可用",
       "RetentionUnknown": "未知",
       "RetentionMs": "{0} ms"
     },
     "Dialog": {
       "CreateTitle": "创建 Kafka 主题",
+      "MessagesTitle": "{0} 的消息",
       "PartitionsTitle": "增加分区",
       "RetentionTitle": "设置保留时间",
       "PartitionsMessage": "主题 {0} 当前有 {1} 个分区。Kafka 只允许增加分区数量。",
       "RetentionMessage": "设置主题 {0} 的 retention.ms。"
+    },
+    "MessagesDialog": {
+      "ReadHint": "显示最多 {0} 条最近消息，采样时间 {1}。此预览不会提交消费者 offset。",
+      "Empty": "在该主题末尾附近未找到消息。",
+      "OffsetFormat": "分区 {0}，offset {1}",
+      "Key": "Key",
+      "Encoding": "编码",
+      "Size": "大小",
+      "SizeBytes": "{0} bytes",
+      "Truncated": "负载已截断后显示。"
     },
     "Confirm": {
       "DeleteTitle": "删除 Kafka 主题",

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
@@ -113,7 +113,11 @@
       "Topics": "主题",
       "TopicsHint": "通过 Kafka 元数据可见",
       "ConsumerGroups": "消费者组",
-      "ConsumerGroupsHint": "来自 Kafka 管理 API 描述"
+      "ConsumerGroupsHint": "来自 Kafka 管理 API 描述",
+      "WriteRate": "写入速率",
+      "WriteRateHint": "来自最新 offset 增长",
+      "ConsumeRate": "消费速率",
+      "ConsumeRateHint": "来自最新提交 offset 增长"
     },
     "Modes": {
       "DirectKafka": "直接 Kafka",
@@ -281,11 +285,15 @@
       "Brokers": "Broker",
       "Topics": "主题",
       "Groups": "消费者组",
+      "WriteRate": "写入速率",
+      "ConsumeRate": "消费速率",
       "Lag": "Lag",
       "Message": "消息"
     },
     "Values": {
       "LagUnknown": "未知",
+      "RateUnknown": "未知",
+      "RatePerSecond": "{0} msg/s",
       "NoMessage": "正常"
     },
     "Messages": {

--- a/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
+++ b/Monica.EventBus.Kafka/Localization/EventBusKafkaResource/zh-CN.json
@@ -1,0 +1,273 @@
+{
+  "Api": {
+    "Integration": {
+      "Get": {
+        "Summary": "获取 Kafka EventBus 集成状态",
+        "Description": "返回当前 EventBus Provider 以及 Kafka 集成可视状态。"
+      }
+    },
+    "Clusters": {
+      "List": {
+        "Summary": "列出 Kafka 集群",
+        "Description": "列出通过模块配置或控制台配置的 Kafka 集群。"
+      },
+      "Upsert": {
+        "Summary": "新建或更新 Kafka 集群",
+        "Description": "保存 Kafka 集群配置，用于控制台展示和管理操作。"
+      },
+      "Delete": {
+        "Summary": "删除 Kafka 集群",
+        "Description": "删除控制台管理的 Kafka 集群及其采样快照。"
+      },
+      "Test": {
+        "Summary": "测试 Kafka 集群连接",
+        "Description": "对 Kafka 集群执行直接 Broker 元数据探测。"
+      }
+    },
+    "Dashboard": {
+      "Get": {
+        "Summary": "获取 Kafka 仪表盘数据",
+        "Description": "返回选中 Kafka 集群的仪表盘聚合数据。"
+      }
+    },
+    "Topics": {
+      "List": {
+        "Summary": "列出 Kafka 主题",
+        "Description": "列出 Kafka 集群中的主题。"
+      },
+      "Create": {
+        "Summary": "创建 Kafka 主题",
+        "Description": "通过直接 Kafka 管理访问创建主题。"
+      },
+      "Delete": {
+        "Summary": "删除 Kafka 主题",
+        "Description": "通过直接 Kafka 管理访问删除主题。"
+      },
+      "Partitions": {
+        "Summary": "增加 Kafka 主题分区",
+        "Description": "增加主题的分区数量。"
+      },
+      "Retention": {
+        "Summary": "更新 Kafka 主题保留时间",
+        "Description": "更新主题的 retention.ms 配置。"
+      }
+    },
+    "ConsumerGroups": {
+      "List": {
+        "Summary": "列出 Kafka 消费者组",
+        "Description": "列出直接 Kafka 管理访问可见的消费者组。"
+      }
+    },
+    "Performance": {
+      "History": {
+        "Summary": "获取 Kafka 性能历史",
+        "Description": "返回集群最近的 Kafka 性能快照。"
+      },
+      "Capture": {
+        "Summary": "采集 Kafka 性能",
+        "Description": "采集 Broker、主题和消费者组快照。"
+      }
+    }
+  },
+  "Common": {
+    "Actions": {
+      "Cancel": "取消",
+      "Delete": "删除",
+      "Edit": "编辑",
+      "Refresh": "刷新",
+      "Save": "保存",
+      "Select": "选择"
+    }
+  },
+  "Page": {
+    "PageTitle": "Kafka EventBus",
+    "Eyebrow": "EventBus 集成",
+    "Title": "Kafka EventBus 控制台",
+    "Subtitle": "查看 Kafka 支撑的 EventBus 集成、集群、主题、消费者组和性能快照。",
+    "States": {
+      "Loading": "正在加载 Kafka 控制台",
+      "LoadingDescription": "正在解析 EventBus Provider 状态和已配置的 Kafka 集群。"
+    },
+    "Messages": {
+      "OperationFailed": "操作失败。",
+      "RefreshSucceeded": "Kafka 控制台已刷新。"
+    }
+  },
+  "Tabs": {
+    "Dashboard": "仪表盘",
+    "Clusters": "集群",
+    "Topics": "主题",
+    "ConsumerGroups": "消费者组",
+    "Performance": "性能"
+  },
+  "Dashboard": {
+    "Cards": {
+      "Provider": "当前 Provider",
+      "Brokers": "Broker",
+      "BrokersHint": "来自最新直接元数据或快照",
+      "Topics": "主题",
+      "TopicsHint": "通过 Kafka 元数据可见",
+      "ConsumerGroups": "消费者组",
+      "ConsumerGroupsHint": "来自 Kafka 管理 API 描述"
+    },
+    "Modes": {
+      "DirectKafka": "直接 Kafka",
+      "DaprKafka": "Dapr-backed Kafka",
+      "DaprNonKafka": "Dapr 未声明 Kafka",
+      "NotConfigured": "未配置",
+      "Unknown": "未知"
+    },
+    "SelectedCluster": {
+      "None": "未选择集群",
+      "NoneDescription": "新建或配置 Kafka 集群后可启用控制台视图。",
+      "ExternalCredentials": "Kafka 凭据由 Monica 外部管理。"
+    }
+  },
+  "Clusters": {
+    "Title": "Kafka 集群",
+    "Empty": "当前没有可见 Kafka 集群。请新建集群或通过模块配置声明集群。",
+    "Actions": {
+      "New": "新建集群",
+      "Test": "测试连接"
+    },
+    "Columns": {
+      "Name": "名称",
+      "Bootstrap": "Bootstrap",
+      "Mode": "模式",
+      "Status": "状态",
+      "Actions": "操作"
+    },
+    "Values": {
+      "ExternalBootstrap": "外部管理"
+    },
+    "Modes": {
+      "DaprBacked": "Dapr 支撑",
+      "Direct": "直接"
+    },
+    "Status": {
+      "Reachable": "可连接",
+      "Unknown": "未测试",
+      "Limited": "受限"
+    },
+    "Dialog": {
+      "CreateTitle": "新建 Kafka 集群",
+      "EditTitle": "编辑 Kafka 集群"
+    },
+    "Confirm": {
+      "DeleteTitle": "删除 Kafka 集群",
+      "DeleteMessage": "删除集群 {0} 及其采样快照？"
+    },
+    "Messages": {
+      "Saved": "Kafka 集群已保存。",
+      "Deleted": "Kafka 集群已删除。",
+      "TestSucceeded": "Kafka 集群可连接。"
+    },
+    "Fields": {
+      "DisplayName": "显示名称",
+      "ClusterId": "集群 ID",
+      "BootstrapServers": "Bootstrap Servers",
+      "ClientId": "Client ID",
+      "JmxEndpoint": "JMX 端点",
+      "SecurityProtocol": "安全协议",
+      "SaslMechanism": "SASL 机制",
+      "SaslUsername": "SASL 用户名",
+      "SaslPassword": "SASL 密码",
+      "SslCaLocation": "SSL CA 路径",
+      "IsDaprBacked": "支撑 Dapr pub/sub",
+      "CredentialsManagedExternally": "凭据由外部管理",
+      "DaprPubSubName": "Dapr pub/sub 名称"
+    },
+    "Validation": {
+      "DisplayNameRequired": "显示名称必填。",
+      "BootstrapRequired": "当凭据由 Monica 管理时，Bootstrap Servers 必填。"
+    }
+  },
+  "Topics": {
+    "Title": "主题",
+    "Unavailable": "主题管理需要直接 Kafka Broker 访问。",
+    "Empty": "选中集群未返回主题。",
+    "Actions": {
+      "Create": "创建主题",
+      "Partitions": "增加分区",
+      "Retention": "设置保留时间"
+    },
+    "Columns": {
+      "Name": "名称",
+      "Partitions": "分区",
+      "Replication": "副本",
+      "Retention": "保留时间",
+      "Actions": "操作"
+    },
+    "Values": {
+      "Internal": "内部主题",
+      "RetentionUnknown": "未知",
+      "RetentionMs": "{0} ms"
+    },
+    "Dialog": {
+      "CreateTitle": "创建 Kafka 主题",
+      "PartitionsTitle": "增加分区",
+      "RetentionTitle": "设置保留时间",
+      "PartitionsMessage": "主题 {0} 当前有 {1} 个分区。Kafka 只允许增加分区数量。",
+      "RetentionMessage": "设置主题 {0} 的 retention.ms。"
+    },
+    "Confirm": {
+      "DeleteTitle": "删除 Kafka 主题",
+      "DeleteMessage": "删除主题 {0}？"
+    },
+    "Messages": {
+      "Created": "Kafka 主题已创建。",
+      "Deleted": "Kafka 主题已删除。",
+      "PartitionsUpdated": "Kafka 主题分区已更新。",
+      "RetentionUpdated": "Kafka 主题保留时间已更新。"
+    },
+    "Fields": {
+      "TopicName": "主题名称",
+      "Partitions": "分区数",
+      "ReplicationFactor": "副本因子",
+      "RetentionMs": "Retention ms",
+      "IncreaseTo": "增加到"
+    },
+    "Validation": {
+      "NameRequired": "主题名称必填。",
+      "PartitionIncreaseRequired": "新的分区数量必须大于当前分区数量。",
+      "RetentionRequired": "保留时间必须大于 0。"
+    }
+  },
+  "ConsumerGroups": {
+    "Title": "消费者组",
+    "Unavailable": "消费者组查看需要直接 Kafka Broker 访问。",
+    "Empty": "选中集群未返回消费者组。",
+    "Columns": {
+      "GroupId": "Group ID",
+      "State": "状态",
+      "Members": "成员",
+      "Lag": "Lag"
+    },
+    "Values": {
+      "LagUnknown": "未知"
+    }
+  },
+  "Performance": {
+    "Title": "性能快照",
+    "Unavailable": "性能采样需要直接 Kafka Broker 访问。",
+    "Empty": "尚未采集性能快照。",
+    "Actions": {
+      "Capture": "采集"
+    },
+    "Columns": {
+      "CapturedAt": "采集时间",
+      "Brokers": "Broker",
+      "Topics": "主题",
+      "Groups": "消费者组",
+      "Lag": "Lag",
+      "Message": "消息"
+    },
+    "Values": {
+      "LagUnknown": "未知",
+      "NoMessage": "正常"
+    },
+    "Messages": {
+      "Captured": "Kafka 性能快照已采集。"
+    }
+  }
+}

--- a/Monica.EventBus.Kafka/Models/KafkaClusterConfig.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaClusterConfig.cs
@@ -1,0 +1,160 @@
+namespace Monica.EventBus.Kafka.Models;
+
+/// <summary>
+/// Developer or runtime supplied Kafka cluster connection configuration.
+/// </summary>
+public sealed class KafkaClusterConfig
+{
+    /// <summary>
+    /// Stable cluster identifier used by UI state, APIs, and persisted snapshots.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable cluster name displayed in the Kafka console.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Kafka bootstrap server list in the standard host:port comma-separated format.
+    /// </summary>
+    public string BootstrapServers { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional Kafka client identifier used by admin, producer, and consumer clients.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Optional Confluent Kafka security protocol name, such as Plaintext, SaslPlaintext, SaslSsl, or Ssl.
+    /// </summary>
+    public string? SecurityProtocol { get; set; }
+
+    /// <summary>
+    /// Optional SASL mechanism name, such as Plain, ScramSha256, or ScramSha512.
+    /// </summary>
+    public string? SaslMechanism { get; set; }
+
+    /// <summary>
+    /// Optional SASL user name. Leave empty when credentials are managed outside Monica, such as in Dapr.
+    /// </summary>
+    public string? SaslUsername { get; set; }
+
+    /// <summary>
+    /// Optional SASL password. Leave empty when credentials are managed outside Monica, such as in Dapr.
+    /// </summary>
+    public string? SaslPassword { get; set; }
+
+    /// <summary>
+    /// Optional CA certificate path used by SSL-enabled Kafka clusters.
+    /// </summary>
+    public string? SslCaLocation { get; set; }
+
+    /// <summary>
+    /// Optional JMX endpoint used for host-level metrics when available.
+    /// </summary>
+    public string? JmxEndpoint { get; set; }
+
+    /// <summary>
+    /// Dapr pub/sub component name when this cluster is backing a Dapr EventBus provider.
+    /// </summary>
+    public string? DaprPubSubName { get; set; }
+
+    /// <summary>
+    /// Whether this cluster is declared as the backing broker for a Dapr pub/sub component.
+    /// </summary>
+    public bool IsDaprBacked { get; set; }
+
+    /// <summary>
+    /// Whether broker credentials are intentionally stored outside Monica.
+    /// </summary>
+    public bool CredentialsManagedExternally { get; set; }
+
+    /// <summary>
+    /// UTC creation time for runtime-created cluster records.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// UTC update time for runtime-created cluster records.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Returns whether Monica has enough broker details to perform direct Kafka admin operations.
+    /// </summary>
+    public bool HasDirectKafkaAccess => !string.IsNullOrWhiteSpace(BootstrapServers) && !CredentialsManagedExternally;
+
+    /// <summary>
+    /// Normalizes defaults and trims user-provided values.
+    /// </summary>
+    /// <returns>The current configuration instance.</returns>
+    public KafkaClusterConfig Normalize()
+    {
+        ClusterId = string.IsNullOrWhiteSpace(ClusterId)
+            ? BuildClusterId(DisplayName, BootstrapServers)
+            : ClusterId.Trim();
+        DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? ClusterId : DisplayName.Trim();
+        BootstrapServers = BootstrapServers.Trim();
+        ClientId = NormalizeOptional(ClientId);
+        SecurityProtocol = NormalizeOptional(SecurityProtocol);
+        SaslMechanism = NormalizeOptional(SaslMechanism);
+        SaslUsername = NormalizeOptional(SaslUsername);
+        SaslPassword = NormalizeOptional(SaslPassword);
+        SslCaLocation = NormalizeOptional(SslCaLocation);
+        JmxEndpoint = NormalizeOptional(JmxEndpoint);
+        DaprPubSubName = NormalizeOptional(DaprPubSubName);
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a detached copy safe for persistence or UI mutation.
+    /// </summary>
+    public KafkaClusterConfig Clone()
+    {
+        return new KafkaClusterConfig
+        {
+            ClusterId = ClusterId,
+            DisplayName = DisplayName,
+            BootstrapServers = BootstrapServers,
+            ClientId = ClientId,
+            SecurityProtocol = SecurityProtocol,
+            SaslMechanism = SaslMechanism,
+            SaslUsername = SaslUsername,
+            SaslPassword = SaslPassword,
+            SslCaLocation = SslCaLocation,
+            JmxEndpoint = JmxEndpoint,
+            DaprPubSubName = DaprPubSubName,
+            IsDaprBacked = IsDaprBacked,
+            CredentialsManagedExternally = CredentialsManagedExternally,
+            CreatedAt = CreatedAt,
+            UpdatedAt = UpdatedAt
+        };
+    }
+
+    private static string BuildClusterId(string displayName, string bootstrapServers)
+    {
+        var source = !string.IsNullOrWhiteSpace(displayName) ? displayName : bootstrapServers;
+        var normalized = new string(source.Trim()
+            .Select(ch => char.IsLetterOrDigit(ch) ? char.ToLowerInvariant(ch) : '-')
+            .ToArray())
+            .Trim('-');
+        return string.IsNullOrWhiteSpace(normalized) ? Guid.NewGuid().ToString("N") : normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}
+
+/// <summary>
+/// Request used to create or update a Kafka cluster from the console.
+/// </summary>
+public sealed class KafkaClusterUpsertRequest
+{
+    /// <summary>
+    /// Cluster configuration to save.
+    /// </summary>
+    public KafkaClusterConfig Cluster { get; set; } = new();
+}

--- a/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
@@ -1,0 +1,311 @@
+namespace Monica.EventBus.Kafka.Models;
+
+/// <summary>
+/// Current Kafka EventBus integration state displayed by the console.
+/// </summary>
+public sealed class KafkaIntegrationSnapshot
+{
+    /// <summary>
+    /// Resolved integration mode.
+    /// </summary>
+    public KafkaIntegrationMode Mode { get; set; }
+
+    /// <summary>
+    /// Display name for the active distributed EventBus provider.
+    /// </summary>
+    public string ActiveProviderName { get; set; } = "Unknown";
+
+    /// <summary>
+    /// Dapr pub/sub component name when Dapr-backed Kafka is configured.
+    /// </summary>
+    public string? DaprPubSubName { get; set; }
+
+    /// <summary>
+    /// Cluster id selected as the primary Kafka integration target.
+    /// </summary>
+    public string? PrimaryClusterId { get; set; }
+
+    /// <summary>
+    /// Console capabilities available for the active integration.
+    /// </summary>
+    public KafkaConsoleCapabilities Capabilities { get; set; }
+
+    /// <summary>
+    /// Human-readable details explaining unavailable or degraded capabilities.
+    /// </summary>
+    public IReadOnlyList<string> Messages { get; set; } = [];
+}
+
+/// <summary>
+/// Summarizes a Kafka cluster and its last known console state.
+/// </summary>
+public sealed class KafkaClusterSummary
+{
+    /// <summary>
+    /// Cluster configuration.
+    /// </summary>
+    public KafkaClusterConfig Config { get; set; } = new();
+
+    /// <summary>
+    /// Whether the last connection probe succeeded.
+    /// </summary>
+    public bool IsReachable { get; set; }
+
+    /// <summary>
+    /// Last connection or sampling error, if any.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Broker count from the last metadata query.
+    /// </summary>
+    public int BrokerCount { get; set; }
+
+    /// <summary>
+    /// Topic count from the last metadata query.
+    /// </summary>
+    public int TopicCount { get; set; }
+
+    /// <summary>
+    /// Consumer group count from the last group query.
+    /// </summary>
+    public int ConsumerGroupCount { get; set; }
+
+    /// <summary>
+    /// Time when the summary was captured.
+    /// </summary>
+    public DateTimeOffset CapturedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Kafka broker metadata.
+/// </summary>
+public sealed class KafkaBrokerInfo
+{
+    /// <summary>
+    /// Broker id assigned by Kafka.
+    /// </summary>
+    public int BrokerId { get; set; }
+
+    /// <summary>
+    /// Broker host name or address.
+    /// </summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Broker port.
+    /// </summary>
+    public int Port { get; set; }
+}
+
+/// <summary>
+/// Kafka topic summary displayed in topic management.
+/// </summary>
+public sealed class KafkaTopicSummary
+{
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of partitions in the topic.
+    /// </summary>
+    public int Partitions { get; set; }
+
+    /// <summary>
+    /// Best-effort replication factor calculated from partition metadata.
+    /// </summary>
+    public int ReplicationFactor { get; set; }
+
+    /// <summary>
+    /// Whether the topic is an internal Kafka topic.
+    /// </summary>
+    public bool IsInternal { get; set; }
+
+    /// <summary>
+    /// Optional retention time in milliseconds.
+    /// </summary>
+    public long? RetentionMs { get; set; }
+}
+
+/// <summary>
+/// Request for creating a Kafka topic.
+/// </summary>
+public sealed class KafkaTopicCreateRequest
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of partitions to create.
+    /// </summary>
+    public int Partitions { get; set; } = 1;
+
+    /// <summary>
+    /// Replication factor to request.
+    /// </summary>
+    public short ReplicationFactor { get; set; } = 1;
+
+    /// <summary>
+    /// Optional retention time in milliseconds.
+    /// </summary>
+    public long? RetentionMs { get; set; }
+}
+
+/// <summary>
+/// Request for increasing a topic's partition count.
+/// </summary>
+public sealed class KafkaTopicPartitionRequest
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// New total partition count. Kafka does not allow reducing partitions.
+    /// </summary>
+    public int IncreaseTo { get; set; }
+}
+
+/// <summary>
+/// Request for updating topic retention.
+/// </summary>
+public sealed class KafkaTopicRetentionRequest
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Retention time in milliseconds.
+    /// </summary>
+    public long RetentionMs { get; set; }
+}
+
+/// <summary>
+/// Consumer group summary displayed in the console.
+/// </summary>
+public sealed class KafkaConsumerGroupSummary
+{
+    /// <summary>
+    /// Consumer group id.
+    /// </summary>
+    public string GroupId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current group state reported by Kafka.
+    /// </summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Member count from consumer group description.
+    /// </summary>
+    public int MemberCount { get; set; }
+
+    /// <summary>
+    /// Total lag when it can be calculated; otherwise null.
+    /// </summary>
+    public long? TotalLag { get; set; }
+}
+
+/// <summary>
+/// Cluster performance snapshot retained by the Kafka console.
+/// </summary>
+public sealed class KafkaPerformanceSnapshot
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC capture time.
+    /// </summary>
+    public DateTimeOffset CapturedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Broker count.
+    /// </summary>
+    public int BrokerCount { get; set; }
+
+    /// <summary>
+    /// Topic count.
+    /// </summary>
+    public int TopicCount { get; set; }
+
+    /// <summary>
+    /// Consumer group count.
+    /// </summary>
+    public int ConsumerGroupCount { get; set; }
+
+    /// <summary>
+    /// Total consumer lag when it can be calculated.
+    /// </summary>
+    public long? TotalLag { get; set; }
+
+    /// <summary>
+    /// Whether JMX metrics were included in this snapshot.
+    /// </summary>
+    public bool IncludesJmxMetrics { get; set; }
+
+    /// <summary>
+    /// Optional diagnostic message recorded during sampling.
+    /// </summary>
+    public string? Message { get; set; }
+}
+
+/// <summary>
+/// Dashboard aggregate for the selected Kafka cluster.
+/// </summary>
+public sealed class KafkaDashboardSnapshot
+{
+    /// <summary>
+    /// Current integration state.
+    /// </summary>
+    public KafkaIntegrationSnapshot Integration { get; set; } = new();
+
+    /// <summary>
+    /// Selected cluster summary.
+    /// </summary>
+    public KafkaClusterSummary? SelectedCluster { get; set; }
+
+    /// <summary>
+    /// Latest performance snapshot for the selected cluster.
+    /// </summary>
+    public KafkaPerformanceSnapshot? LatestPerformance { get; set; }
+
+    /// <summary>
+    /// Topic count shown by the dashboard.
+    /// </summary>
+    public int TopicCount { get; set; }
+
+    /// <summary>
+    /// Consumer group count shown by the dashboard.
+    /// </summary>
+    public int ConsumerGroupCount { get; set; }
+
+    /// <summary>
+    /// Broker count shown by the dashboard.
+    /// </summary>
+    public int BrokerCount { get; set; }
+}

--- a/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
@@ -203,6 +203,119 @@ public sealed class KafkaTopicRetentionRequest
 }
 
 /// <summary>
+/// Request for reading a bounded sample of topic messages without committing consumer offsets.
+/// </summary>
+public sealed class KafkaTopicMessagesRequest
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maximum number of messages to return. The module clamps this to its configured preview limit.
+    /// </summary>
+    public int MaxMessages { get; set; } = 20;
+}
+
+/// <summary>
+/// Bounded topic message sample returned to the Kafka console.
+/// </summary>
+public sealed class KafkaTopicMessageBatch
+{
+    /// <summary>
+    /// Target cluster id.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the preview started from each partition's latest offsets.
+    /// </summary>
+    public bool ReadFromEnd { get; set; } = true;
+
+    /// <summary>
+    /// Maximum number of messages requested after module-level clamping.
+    /// </summary>
+    public int MaxMessages { get; set; }
+
+    /// <summary>
+    /// Time when the sample was captured.
+    /// </summary>
+    public DateTimeOffset CapturedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Sampled messages ordered from newest to oldest.
+    /// </summary>
+    public IReadOnlyList<KafkaTopicMessageSample> Messages { get; set; } = [];
+}
+
+/// <summary>
+/// Kafka message metadata and decoded content shown in the console.
+/// </summary>
+public sealed class KafkaTopicMessageSample
+{
+    /// <summary>
+    /// Topic name.
+    /// </summary>
+    public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Partition that contains the message.
+    /// </summary>
+    public int Partition { get; set; }
+
+    /// <summary>
+    /// Kafka offset within the partition.
+    /// </summary>
+    public long Offset { get; set; }
+
+    /// <summary>
+    /// Producer timestamp when Kafka exposes it.
+    /// </summary>
+    public DateTimeOffset? Timestamp { get; set; }
+
+    /// <summary>
+    /// Decoded message key, if present.
+    /// </summary>
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Decoded message value, base64 payload, or null for tombstone messages.
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// Encoding used for <see cref="Value"/>.
+    /// </summary>
+    public string ValueEncoding { get; set; } = "utf-8";
+
+    /// <summary>
+    /// Original value payload length in bytes.
+    /// </summary>
+    public int ValueSizeBytes { get; set; }
+
+    /// <summary>
+    /// Whether the value was truncated before display.
+    /// </summary>
+    public bool IsTruncated { get; set; }
+
+    /// <summary>
+    /// Whether the Kafka value is null, which represents a compacted-topic tombstone.
+    /// </summary>
+    public bool IsTombstone { get; set; }
+}
+
+/// <summary>
 /// Consumer group summary displayed in the console.
 /// </summary>
 public sealed class KafkaConsumerGroupSummary

--- a/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
@@ -377,6 +377,26 @@ public sealed class KafkaPerformanceSnapshot
     public long? TotalLag { get; set; }
 
     /// <summary>
+    /// Sum of latest offsets across sampled non-internal topic partitions.
+    /// </summary>
+    public long? TotalLogEndOffset { get; set; }
+
+    /// <summary>
+    /// Sum of committed offsets across sampled consumer groups and non-internal topic partitions.
+    /// </summary>
+    public long? TotalConsumerCommittedOffset { get; set; }
+
+    /// <summary>
+    /// Estimated topic write rate in messages per second, calculated from latest offset growth.
+    /// </summary>
+    public double? MessageWriteRatePerSecond { get; set; }
+
+    /// <summary>
+    /// Estimated consumer processing rate in messages per second, calculated from committed offset growth.
+    /// </summary>
+    public double? MessageConsumeRatePerSecond { get; set; }
+
+    /// <summary>
     /// Whether JMX metrics were included in this snapshot.
     /// </summary>
     public bool IncludesJmxMetrics { get; set; }
@@ -385,6 +405,27 @@ public sealed class KafkaPerformanceSnapshot
     /// Optional diagnostic message recorded during sampling.
     /// </summary>
     public string? Message { get; set; }
+}
+
+/// <summary>
+/// Kafka offset totals used to calculate performance rates.
+/// </summary>
+public sealed class KafkaPerformanceOffsetTotals
+{
+    /// <summary>
+    /// Sum of latest offsets across sampled non-internal topic partitions.
+    /// </summary>
+    public long TotalLogEndOffset { get; set; }
+
+    /// <summary>
+    /// Sum of committed offsets across sampled consumer groups and non-internal topic partitions.
+    /// </summary>
+    public long? TotalConsumerCommittedOffset { get; set; }
+
+    /// <summary>
+    /// Total lag calculated from latest offsets and committed offsets when consumer offsets are available.
+    /// </summary>
+    public long? TotalLag { get; set; }
 }
 
 /// <summary>

--- a/Monica.EventBus.Kafka/Models/KafkaIntegrationMode.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaIntegrationMode.cs
@@ -1,0 +1,69 @@
+namespace Monica.EventBus.Kafka.Models;
+
+/// <summary>
+/// Describes how Monica is currently integrated with Kafka.
+/// </summary>
+public enum KafkaIntegrationMode
+{
+    /// <summary>
+    /// No Kafka integration has been configured.
+    /// </summary>
+    NotConfigured,
+
+    /// <summary>
+    /// Monica uses the native Kafka provider as the distributed EventBus provider.
+    /// </summary>
+    DirectKafka,
+
+    /// <summary>
+    /// Monica uses Dapr as the EventBus provider and the configured Dapr pub/sub component is backed by Kafka.
+    /// </summary>
+    DaprKafka,
+
+    /// <summary>
+    /// Monica uses Dapr as the EventBus provider, but no Kafka-backed component is declared.
+    /// </summary>
+    DaprNonKafka,
+
+    /// <summary>
+    /// Monica cannot determine the active distributed EventBus provider.
+    /// </summary>
+    Unknown
+}
+
+/// <summary>
+/// Kafka console capability flags for the selected integration mode and cluster configuration.
+/// </summary>
+[Flags]
+public enum KafkaConsoleCapabilities
+{
+    /// <summary>
+    /// No Kafka console capabilities are available.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The configuration can publish and subscribe to EventBus topics.
+    /// </summary>
+    PublishSubscribe = 1 << 0,
+
+    /// <summary>
+    /// The console can execute Kafka topic administration operations.
+    /// </summary>
+    TopicAdmin = 1 << 1,
+
+    /// <summary>
+    /// The console can inspect consumer groups.
+    /// </summary>
+    ConsumerGroups = 1 << 2,
+
+    /// <summary>
+    /// The console can collect broker, topic, and consumer group snapshots.
+    /// </summary>
+    PerformanceSampling = 1 << 3,
+
+    /// <summary>
+    /// The console can include broker JMX metrics.
+    /// </summary>
+    JmxMetrics = 1 << 4
+}

--- a/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
+++ b/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
@@ -88,6 +88,7 @@ public sealed class ModuleEventBusKafka(ModuleEventBusKafkaOption option)
         services.TryAddSingleton<IKafkaClusterConfigProvider, KafkaClusterConfigProvider>();
         services.TryAddScoped<IKafkaAdminProvider, ConfluentKafkaAdminProvider>();
         services.TryAddScoped<IKafkaMessageReader, ConfluentKafkaMessageReader>();
+        services.TryAddScoped<IKafkaPerformanceMetricsProvider, ConfluentKafkaPerformanceMetricsProvider>();
         services.TryAddScoped<KafkaIntegrationService>();
         services.TryAddScoped<KafkaClusterService>();
         services.TryAddScoped<KafkaTopicService>();

--- a/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
+++ b/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
@@ -1,0 +1,457 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Monica.Core;
+using Monica.Core.Localization.Services;
+using Monica.Core.Modularity;
+using Monica.Core.Modularity.Abstractions;
+using Monica.Core.Modularity.Annotations;
+using Monica.Core.Modularity.Models;
+using Monica.Core.Results;
+using Monica.EventBus.Abstractions;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Facades;
+using Monica.EventBus.Kafka.Localization;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Providers.ConfluentKafka;
+using Monica.EventBus.Kafka.Providers.EfCore;
+using Monica.EventBus.Kafka.Services;
+
+// ReSharper disable once CheckNamespace
+namespace Monica.Modules;
+
+/// <summary>
+/// Builder extensions for the Kafka EventBus module.
+/// </summary>
+public static class ModuleEventBusKafkaBuilderExtensions
+{
+    extension(Mo)
+    {
+        /// <summary>
+        /// Registers the Kafka EventBus provider and Kafka management console services.
+        /// </summary>
+        /// <param name="action">Optional module option configuration.</param>
+        /// <returns>The Kafka EventBus guide used for chained configuration.</returns>
+        public static ModuleEventBusKafkaGuide AddEventBusKafka(Action<ModuleEventBusKafkaOption>? action = null)
+        {
+            return new ModuleEventBusKafkaGuide().Register(action);
+        }
+    }
+}
+
+/// <summary>
+/// Kafka EventBus provider and management console backend module.
+/// </summary>
+/// <param name="option">Module options.</param>
+[ModuleKey(BuiltInModuleKey.EventBusKafka)]
+public sealed class ModuleEventBusKafka(ModuleEventBusKafkaOption option)
+    : WebModuleBase<ModuleEventBusKafka, ModuleEventBusKafkaOption, ModuleEventBusKafkaGuide>(option),
+      IEventBusProviderModule
+{
+    /// <inheritdoc />
+    public ModuleKey ProvidesFor => BuiltInModuleKey.EventBus;
+
+    /// <inheritdoc />
+    public EventBusProviderKind ProviderType => EventBusProviderKind.Kafka;
+
+    /// <inheritdoc />
+    public EventBusProviderCapabilities Capabilities =>
+        EventBusProviderCapabilities.BulkPublish |
+        EventBusProviderCapabilities.Streaming;
+
+    /// <inheritdoc />
+    public string DisplayName => "Kafka";
+
+    /// <inheritdoc />
+    public override bool CanDowngradeToNonWebModule()
+    {
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override void ClaimDependencies()
+    {
+        DependsOnModule<ModuleEventBusGuide>().Register();
+        DependsOnModule<ModuleJsonSerializationGuide>().Register();
+        DependsOnModule<ModuleLocalizationGuide>().Register()
+            .AddResource<EventBusKafkaResource>();
+    }
+
+    /// <inheritdoc />
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.TryAddSingleton<IKafkaConsoleRepository, InMemoryKafkaConsoleRepository>();
+        services.TryAddSingleton<IKafkaClusterConfigProvider, KafkaClusterConfigProvider>();
+        services.TryAddScoped<IKafkaAdminProvider, ConfluentKafkaAdminProvider>();
+        services.TryAddScoped<KafkaIntegrationService>();
+        services.TryAddScoped<KafkaClusterService>();
+        services.TryAddScoped<KafkaTopicService>();
+        services.TryAddScoped<KafkaConsumerGroupService>();
+        services.TryAddScoped<KafkaPerformanceService>();
+        services.TryAddScoped<KafkaDashboardService>();
+        services.TryAddScoped<KafkaConsoleFacade>();
+    }
+
+    /// <inheritdoc />
+    public override void ConfigureEndpoints(IApplicationBuilder app)
+    {
+        UseEndpoints(app, endpoints =>
+        {
+            var tagName = Option.GetApiGroupName();
+
+            endpoints.MapGet("/eventbus-kafka/integration",
+                    async ([FromServices] KafkaConsoleFacade facade, CancellationToken cancellationToken) =>
+                        (await facade.GetIntegrationAsync(cancellationToken)).GetResponse())
+                .WithName("GetEventBusKafkaIntegration")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Integration:Get:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Integration:Get:Description"));
+
+            endpoints.MapGet("/eventbus-kafka/clusters",
+                    async ([FromServices] KafkaConsoleFacade facade, CancellationToken cancellationToken) =>
+                        (await facade.ListClustersAsync(cancellationToken)).GetResponse())
+                .WithName("ListEventBusKafkaClusters")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:List:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:List:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/clusters",
+                    async ([FromBody] KafkaClusterUpsertRequest request,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.UpsertClusterAsync(request, cancellationToken)).GetResponse())
+                .WithName("UpsertEventBusKafkaCluster")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Upsert:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Upsert:Description"));
+
+            endpoints.MapDelete("/eventbus-kafka/clusters/{clusterId}",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.DeleteClusterAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("DeleteEventBusKafkaCluster")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Delete:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Delete:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/clusters/{clusterId}/test",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.TestClusterAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("TestEventBusKafkaCluster")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Test:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Clusters:Test:Description"));
+
+            endpoints.MapGet("/eventbus-kafka/clusters/{clusterId}/dashboard",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.GetDashboardAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("GetEventBusKafkaDashboard")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Dashboard:Get:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Dashboard:Get:Description"));
+
+            endpoints.MapGet("/eventbus-kafka/clusters/{clusterId}/topics",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.ListTopicsAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("ListEventBusKafkaTopics")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:List:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:List:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/topics",
+                    async ([FromBody] KafkaTopicCreateRequest request,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.CreateTopicAsync(request, cancellationToken)).GetResponse())
+                .WithName("CreateEventBusKafkaTopic")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Create:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Create:Description"));
+
+            endpoints.MapDelete("/eventbus-kafka/clusters/{clusterId}/topics/{topicName}",
+                    async ([FromRoute] string clusterId,
+                        [FromRoute] string topicName,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.DeleteTopicAsync(clusterId, topicName, cancellationToken)).GetResponse())
+                .WithName("DeleteEventBusKafkaTopic")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Delete:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Delete:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/topics/partitions",
+                    async ([FromBody] KafkaTopicPartitionRequest request,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.IncreasePartitionsAsync(request, cancellationToken)).GetResponse())
+                .WithName("IncreaseEventBusKafkaTopicPartitions")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Partitions:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Partitions:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/topics/retention",
+                    async ([FromBody] KafkaTopicRetentionRequest request,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.UpdateRetentionAsync(request, cancellationToken)).GetResponse())
+                .WithName("UpdateEventBusKafkaTopicRetention")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Retention:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Retention:Description"));
+
+            endpoints.MapGet("/eventbus-kafka/clusters/{clusterId}/consumer-groups",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.ListConsumerGroupsAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("ListEventBusKafkaConsumerGroups")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:ConsumerGroups:List:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:ConsumerGroups:List:Description"));
+
+            endpoints.MapGet("/eventbus-kafka/clusters/{clusterId}/performance",
+                    async ([FromRoute] string clusterId,
+                        [FromQuery] int? limit,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.GetPerformanceHistoryAsync(clusterId, limit, cancellationToken)).GetResponse())
+                .WithName("GetEventBusKafkaPerformanceHistory")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Performance:History:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Performance:History:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/clusters/{clusterId}/performance/capture",
+                    async ([FromRoute] string clusterId,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.CapturePerformanceAsync(clusterId, cancellationToken)).GetResponse())
+                .WithName("CaptureEventBusKafkaPerformance")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Performance:Capture:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Performance:Capture:Description"));
+        });
+    }
+}
+
+/// <summary>
+/// Fluent guide for configuring Kafka EventBus and console storage.
+/// </summary>
+public sealed class ModuleEventBusKafkaGuide
+    : WebModuleGuide<ModuleEventBusKafka, ModuleEventBusKafkaOption, ModuleEventBusKafkaGuide>
+{
+    /// <summary>
+    /// Uses the in-memory Kafka console repository.
+    /// </summary>
+    /// <remarks>
+    /// This is the default store. Calling this method explicitly replaces any previous console
+    /// repository registration for hosts that want transient runtime configuration.
+    /// </remarks>
+    /// <returns>The current guide.</returns>
+    public ModuleEventBusKafkaGuide UseInMemoryStore()
+    {
+        ConfigureServices(context =>
+        {
+            context.Services.RemoveAll<IKafkaConsoleRepository>();
+            context.Services.AddSingleton<IKafkaConsoleRepository, InMemoryKafkaConsoleRepository>();
+        }, ModuleRegistrationOrder.PostConfig);
+        return this;
+    }
+
+    /// <summary>
+    /// Uses an EF Core repository for Kafka console clusters and performance snapshots.
+    /// </summary>
+    /// <param name="optionsAction">Configures the EF Core provider and options for the Kafka console DbContext.</param>
+    /// <returns>The current guide.</returns>
+    public ModuleEventBusKafkaGuide UseEfCoreStore(Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)
+    {
+        ArgumentNullException.ThrowIfNull(optionsAction);
+
+        DependsOnModule<ModuleRepositoryGuide>().Register()
+            .AddRepositoryDbContext<KafkaConsoleDbContext>(optionsAction);
+
+        ConfigureServices(context =>
+        {
+            context.Services.RemoveAll<IKafkaConsoleRepository>();
+            context.Services.AddScoped<IKafkaConsoleRepository, EfCoreKafkaConsoleRepository>();
+        }, ModuleRegistrationOrder.PostConfig);
+        return this;
+    }
+
+    /// <summary>
+    /// Declares a visible Kafka cluster without changing the active EventBus provider.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <returns>The current guide.</returns>
+    public ModuleEventBusKafkaGuide AddConfiguredCluster(KafkaClusterConfig cluster)
+    {
+        var normalized = cluster.Clone().Normalize();
+        ConfigureModuleOption(option => option.AddOrReplaceConfiguredCluster(normalized), secondKey: normalized.ClusterId);
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the native Kafka provider as the default distributed EventBus provider.
+    /// </summary>
+    /// <param name="cluster">Cluster used by the native Kafka producer and subscription consumers.</param>
+    /// <returns>The current guide.</returns>
+    /// <remarks>
+    /// This method intentionally performs the provider switch. Registering this module or the UI
+    /// alone does not replace an existing Dapr EventBus provider.
+    /// </remarks>
+    public ModuleEventBusKafkaGuide UseKafkaProvider(KafkaClusterConfig cluster)
+    {
+        var normalized = cluster.Clone().Normalize();
+        normalized.CredentialsManagedExternally = false;
+
+        DependsOnModule<ModuleEventBusGuide>().Register()
+            .UseDistributedEventBus<KafkaEventBusProvider>();
+        DependsOnModule<ModuleHostedServiceGuide>().Register();
+
+        ConfigureModuleOption(option =>
+        {
+            option.DirectEventBusCluster = normalized;
+            option.PrimaryClusterId = normalized.ClusterId;
+            option.AddOrReplaceConfiguredCluster(normalized);
+        }, secondKey: normalized.ClusterId);
+
+        ConfigureServices(context =>
+        {
+            context.Services.AddHostedService<KafkaEventBusSubscriptionHostedService>();
+        }, ModuleRegistrationOrder.PostConfig);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Declares that the active Dapr EventBus pub/sub component is backed by Kafka.
+    /// </summary>
+    /// <param name="cluster">Kafka cluster metadata to show in the console.</param>
+    /// <param name="pubSubName">Dapr pub/sub component name. When omitted, the cluster value or module default is used.</param>
+    /// <param name="credentialsManagedExternally">
+    /// Whether Kafka credentials are owned by Dapr or external infrastructure instead of Monica.
+    /// </param>
+    /// <returns>The current guide.</returns>
+    /// <remarks>
+    /// This method is visibility-only. It does not call <c>UseDistributedEventBus</c> and therefore
+    /// does not alter an existing Dapr EventBus provider.
+    /// </remarks>
+    public ModuleEventBusKafkaGuide UseDaprKafkaIntegration(
+        KafkaClusterConfig cluster,
+        string? pubSubName = null,
+        bool credentialsManagedExternally = true)
+    {
+        var normalized = cluster.Clone().Normalize();
+        normalized.IsDaprBacked = true;
+        normalized.CredentialsManagedExternally = credentialsManagedExternally;
+        normalized.DaprPubSubName = string.IsNullOrWhiteSpace(pubSubName)
+            ? normalized.DaprPubSubName
+            : pubSubName.Trim();
+
+        ConfigureModuleOption(option =>
+        {
+            option.PrimaryClusterId = normalized.ClusterId;
+            option.DaprPubSubName = normalized.DaprPubSubName;
+            option.AddOrReplaceConfiguredCluster(normalized);
+        }, secondKey: normalized.ClusterId);
+
+        return this;
+    }
+}
+
+/// <summary>
+/// Configuration options for the Kafka EventBus provider and console backend.
+/// </summary>
+public sealed class ModuleEventBusKafkaOption : MinimalApiModuleOptions<ModuleEventBusKafka>
+{
+    /// <summary>
+    /// Gets the clusters declared through module configuration.
+    /// </summary>
+    /// <remarks>
+    /// These clusters are visible in the console even when they are not persisted through the
+    /// runtime cluster management page.
+    /// </remarks>
+    public List<KafkaClusterConfig> ConfiguredClusters { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the cluster used by the native Kafka EventBus provider.
+    /// </summary>
+    /// <remarks>
+    /// This value is set by <see cref="ModuleEventBusKafkaGuide.UseKafkaProvider(KafkaClusterConfig)"/>.
+    /// When it is <see langword="null"/>, registering the module will not replace the default
+    /// distributed EventBus provider.
+    /// </remarks>
+    public KafkaClusterConfig? DirectEventBusCluster { get; set; }
+
+    /// <summary>
+    /// Gets or sets the primary cluster selected by integration and dashboard views.
+    /// </summary>
+    public string? PrimaryClusterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Dapr pub/sub component name when Kafka backs the Dapr EventBus provider.
+    /// </summary>
+    public string? DaprPubSubName { get; set; } = "pubsub";
+
+    /// <summary>
+    /// Gets or sets the default Kafka client id used when a cluster does not specify one.
+    /// </summary>
+    public string ClientId { get; set; } = "monica-eventbus-kafka";
+
+    /// <summary>
+    /// Gets or sets the Kafka consumer group id used by native EventBus subscriptions.
+    /// </summary>
+    public string ConsumerGroupId { get; set; } = "monica-eventbus";
+
+    /// <summary>
+    /// Gets or sets the request timeout used by Kafka admin operations.
+    /// </summary>
+    public TimeSpan AdminRequestTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets the maximum time the native Kafka producer waits while flushing on disposal.
+    /// </summary>
+    public TimeSpan ProducerFlushTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets the delay between native Kafka consumer retry attempts after an error.
+    /// </summary>
+    public TimeSpan ConsumerErrorBackoff { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the maximum number of consumer groups described by one console request.
+    /// </summary>
+    public int MaxConsumerGroupsToDescribe { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the default number of performance snapshots returned to the UI.
+    /// </summary>
+    public int PerformanceHistoryLimit { get; set; } = 60;
+
+    /// <summary>
+    /// Gets or sets how long captured performance snapshots are retained.
+    /// </summary>
+    public TimeSpan PerformanceSnapshotRetention { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Adds or replaces a configured cluster using its normalized cluster id.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration to store in the option.</param>
+    public void AddOrReplaceConfiguredCluster(KafkaClusterConfig cluster)
+    {
+        var normalized = cluster.Clone().Normalize();
+        ConfiguredClusters.RemoveAll(existing =>
+            string.Equals(existing.ClusterId, normalized.ClusterId, StringComparison.Ordinal));
+        ConfiguredClusters.Add(normalized);
+    }
+}

--- a/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
+++ b/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
@@ -87,6 +87,7 @@ public sealed class ModuleEventBusKafka(ModuleEventBusKafkaOption option)
         services.TryAddSingleton<IKafkaConsoleRepository, InMemoryKafkaConsoleRepository>();
         services.TryAddSingleton<IKafkaClusterConfigProvider, KafkaClusterConfigProvider>();
         services.TryAddScoped<IKafkaAdminProvider, ConfluentKafkaAdminProvider>();
+        services.TryAddScoped<IKafkaMessageReader, ConfluentKafkaMessageReader>();
         services.TryAddScoped<KafkaIntegrationService>();
         services.TryAddScoped<KafkaClusterService>();
         services.TryAddScoped<KafkaTopicService>();
@@ -209,6 +210,16 @@ public sealed class ModuleEventBusKafka(ModuleEventBusKafkaOption option)
                 .WithTags(tagName)
                 .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Retention:Summary"))
                 .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Retention:Description"));
+
+            endpoints.MapPost("/eventbus-kafka/topics/messages",
+                    async ([FromBody] KafkaTopicMessagesRequest request,
+                        [FromServices] KafkaConsoleFacade facade,
+                        CancellationToken cancellationToken) =>
+                        (await facade.ReadTopicMessagesAsync(request, cancellationToken)).GetResponse())
+                .WithName("ReadEventBusKafkaTopicMessages")
+                .WithTags(tagName)
+                .WithSummary(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Messages:Summary"))
+                .WithDescription(LocalizationManager.Get<EventBusKafkaResource>("Api:Topics:Messages:Description"));
 
             endpoints.MapGet("/eventbus-kafka/clusters/{clusterId}/consumer-groups",
                     async ([FromRoute] string clusterId,
@@ -432,6 +443,33 @@ public sealed class ModuleEventBusKafkaOption : MinimalApiModuleOptions<ModuleEv
     /// Gets or sets the maximum number of consumer groups described by one console request.
     /// </summary>
     public int MaxConsumerGroupsToDescribe { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the maximum number of topic messages a console preview request can return.
+    /// </summary>
+    /// <remarks>
+    /// The UI can request a smaller value, but larger values are clamped to this limit to keep
+    /// diagnostic reads bounded and avoid loading too many payloads into memory.
+    /// </remarks>
+    public int MessagePreviewMaxMessages { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the maximum time spent polling Kafka for one topic message preview.
+    /// </summary>
+    /// <remarks>
+    /// Preview reads use a temporary read-only consumer and stop when this timeout is reached even
+    /// if fewer than the requested number of messages were found.
+    /// </remarks>
+    public TimeSpan MessagePreviewTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the maximum number of value bytes decoded for each previewed message.
+    /// </summary>
+    /// <remarks>
+    /// Larger values are truncated before UTF-8 or base64 conversion so the console can inspect
+    /// large topics without rendering unbounded payloads.
+    /// </remarks>
+    public int MessagePreviewMaxValueBytes { get; set; } = 64 * 1024;
 
     /// <summary>
     /// Gets or sets the default number of performance snapshots returned to the UI.

--- a/Monica.EventBus.Kafka/Modules/ModuleEventBusKafkaUI.cs
+++ b/Monica.EventBus.Kafka/Modules/ModuleEventBusKafkaUI.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.DependencyInjection;
+using Monica.Core;
+using Monica.Core.Modularity;
+using Monica.Core.Modularity.Abstractions;
+using Monica.Core.Modularity.Annotations;
+using Monica.Core.Modularity.Models;
+using Monica.EventBus.Kafka.Localization;
+using Monica.EventBus.Kafka.Pages;
+using Monica.EventBus.Kafka.UIEventBusKafka.State;
+using MudBlazor;
+
+// ReSharper disable once CheckNamespace
+namespace Monica.Modules;
+
+/// <summary>
+/// Builder extensions for the Kafka EventBus console UI module.
+/// </summary>
+public static class ModuleEventBusKafkaUIBuilderExtensions
+{
+    extension(Mo)
+    {
+        /// <summary>
+        /// Registers the Kafka EventBus console UI.
+        /// </summary>
+        /// <param name="action">Optional UI module option configuration.</param>
+        /// <returns>The Kafka EventBus UI guide used for chained configuration.</returns>
+        public static ModuleEventBusKafkaUIGuide AddEventBusKafkaUI(Action<ModuleEventBusKafkaUIOption>? action = null)
+        {
+            return new ModuleEventBusKafkaUIGuide().Register(action);
+        }
+    }
+}
+
+/// <summary>
+/// Kafka EventBus management console UI module.
+/// </summary>
+/// <param name="option">Module options.</param>
+[ModuleKey(BuiltInModuleKey.EventBusKafkaUI)]
+public sealed class ModuleEventBusKafkaUI(ModuleEventBusKafkaUIOption option)
+    : ModuleBase<ModuleEventBusKafkaUI, ModuleEventBusKafkaUIOption, ModuleEventBusKafkaUIGuide>(option)
+{
+    /// <inheritdoc />
+    public override void ClaimDependencies()
+    {
+        DependsOnModule<ModuleEventBusKafkaGuide>().Register();
+        DependsOnModule<ModuleLocalizationGuide>().Register()
+            .AddResource<EventBusKafkaResource>();
+
+        if (Option.DisableKafkaConsolePage)
+        {
+            return;
+        }
+
+        DependsOnModule<ModuleShellUIGuide>().Register()
+            .RegisterUIComponents(registry => registry.RegisterLocalizedComponent<UIEventBusKafkaPage>(
+                UIEventBusKafkaPage.PAGE_URL,
+                "Pages:EventBusKafka:Title",
+                Icons.Material.Filled.Storage,
+                "Categories:Infrastructure",
+                addToNav: true,
+                navOrder: 38));
+    }
+
+    /// <inheritdoc />
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<EventBusKafkaPageState>();
+    }
+}
+
+/// <summary>
+/// Fluent guide for the Kafka EventBus console UI module.
+/// </summary>
+public sealed class ModuleEventBusKafkaUIGuide
+    : ModuleGuide<ModuleEventBusKafkaUI, ModuleEventBusKafkaUIOption, ModuleEventBusKafkaUIGuide>
+{
+}
+
+/// <summary>
+/// Configuration options for the Kafka EventBus console UI module.
+/// </summary>
+public sealed class ModuleEventBusKafkaUIOption : ModuleOptions<ModuleEventBusKafkaUI>
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the Kafka console page should be hidden from navigation.
+    /// </summary>
+    public bool DisableKafkaConsolePage { get; set; }
+}

--- a/Monica.EventBus.Kafka/Monica.EventBus.Kafka.csproj
+++ b/Monica.EventBus.Kafka/Monica.EventBus.Kafka.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <GenerateStaticWebAssetsManifest>true</GenerateStaticWebAssetsManifest>
+    <PackageDescription>Kafka EventBus provider and Kafka operations console for Monica, including Dapr-backed Kafka integration visibility.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.13.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Monica.EventBus\Monica.EventBus.csproj" />
+    <ProjectReference Include="..\Monica.Repository\Monica.Repository.csproj" />
+    <ProjectReference Include="..\Monica.UI\Monica.UI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor
+++ b/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor
@@ -1,0 +1,338 @@
+@attribute [Route(PAGE_URL)]
+@using Monica.EventBus.Kafka.UIEventBusKafka.Components
+@using Monica.EventBus.Kafka.UIEventBusKafka.Dialogs
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject EventBusKafkaPageState PageState
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<PageTitle>@L["Page:PageTitle"]</PageTitle>
+
+<div class="eventbus-kafka-page">
+    <div class="page-banner">
+        <div class="page-banner__copy">
+            <MudText Typo="Typo.overline" Class="page-eyebrow">@L["Page:Eyebrow"]</MudText>
+            <MudText Typo="Typo.h5">@L["Page:Title"]</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["Page:Subtitle"]</MudText>
+        </div>
+
+        <div class="page-banner__actions">
+            <MudTooltip Text="@L["Common:Actions:Refresh"]">
+                <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                               Variant="Variant.Outlined"
+                               Disabled="@PageState.IsBusy"
+                               OnClick="RefreshAsync" />
+            </MudTooltip>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       Disabled="@PageState.IsBusy"
+                       OnClick="OpenCreateClusterDialogAsync">
+                @L["Clusters:Actions:New"]
+            </MudButton>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(PageState.ErrorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+            @PageState.ErrorMessage
+        </MudAlert>
+    }
+
+    @if (PageState.IsLoading)
+    {
+        <div class="page-state">
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+            <MudText Typo="Typo.h6">@L["Page:States:Loading"]</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["Page:States:LoadingDescription"]</MudText>
+        </div>
+    }
+    else
+    {
+        <MudTabs Rounded="true"
+                 Outlined="true"
+                 ApplyEffectsToContainer="true"
+                 TabPanelsClass="eventbus-kafka-tab-panels">
+            <MudTabPanel Text="@L["Tabs:Dashboard"]" Icon="@Icons.Material.Filled.Dashboard">
+                <KafkaDashboardTab State="PageState" OnRefresh="RefreshAsync" />
+            </MudTabPanel>
+            <MudTabPanel Text="@L["Tabs:Clusters"]" Icon="@Icons.Material.Filled.Storage">
+                <KafkaClustersTab State="PageState"
+                                  OnCreate="OpenCreateClusterDialogAsync"
+                                  OnRefresh="RefreshAsync"
+                                  OnSelect="SelectClusterAsync"
+                                  OnEdit="OpenEditClusterDialogAsync"
+                                  OnDelete="DeleteClusterAsync"
+                                  OnTest="TestClusterAsync" />
+            </MudTabPanel>
+            <MudTabPanel Text="@L["Tabs:Topics"]" Icon="@Icons.Material.Filled.Topic">
+                <KafkaTopicsTab State="PageState"
+                                OnCreate="OpenCreateTopicDialogAsync"
+                                OnRefresh="RefreshAsync"
+                                OnDelete="DeleteTopicAsync"
+                                OnIncreasePartitions="OpenIncreasePartitionsDialogAsync"
+                                OnUpdateRetention="OpenRetentionDialogAsync" />
+            </MudTabPanel>
+            <MudTabPanel Text="@L["Tabs:ConsumerGroups"]" Icon="@Icons.Material.Filled.Group">
+                <KafkaConsumerGroupsTab State="PageState" OnRefresh="RefreshAsync" />
+            </MudTabPanel>
+            <MudTabPanel Text="@L["Tabs:Performance"]" Icon="@Icons.Material.Filled.MonitorHeart">
+                <KafkaPerformanceTab State="PageState"
+                                     OnRefresh="RefreshAsync"
+                                     OnCapture="CapturePerformanceAsync" />
+            </MudTabPanel>
+        </MudTabs>
+    }
+</div>
+
+@code {
+    public const string PAGE_URL = "/eventbus-kafka";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await PageState.InitializeAsync();
+        StateHasChanged();
+    }
+
+    private async Task RefreshAsync()
+    {
+        await PageState.RefreshAsync();
+        Snackbar.Add(L["Page:Messages:RefreshSucceeded"], Severity.Success);
+        StateHasChanged();
+    }
+
+    private async Task SelectClusterAsync(KafkaClusterSummary cluster)
+    {
+        await PageState.SelectClusterAsync(cluster.Config.ClusterId);
+        StateHasChanged();
+    }
+
+    private async Task OpenCreateClusterDialogAsync()
+    {
+        await OpenClusterDialogAsync(null);
+    }
+
+    private async Task OpenEditClusterDialogAsync(KafkaClusterSummary cluster)
+    {
+        await OpenClusterDialogAsync(cluster.Config);
+    }
+
+    private async Task OpenClusterDialogAsync(KafkaClusterConfig? cluster)
+    {
+        var parameters = new DialogParameters<CreateKafkaClusterDialog>
+        {
+            { dialog => dialog.Cluster, cluster?.Clone() }
+        };
+
+        var dialog = await DialogService.ShowAsync<CreateKafkaClusterDialog>(
+            cluster is null ? L["Clusters:Dialog:CreateTitle"] : L["Clusters:Dialog:EditTitle"],
+            parameters,
+            DefaultDialogOptions);
+
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not KafkaClusterConfig savedCluster)
+        {
+            return;
+        }
+
+        if (await PageState.UpsertClusterAsync(savedCluster))
+        {
+            Snackbar.Add(L["Clusters:Messages:Saved"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task DeleteClusterAsync(KafkaClusterSummary cluster)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            L["Clusters:Confirm:DeleteTitle"],
+            L["Clusters:Confirm:DeleteMessage", cluster.Config.DisplayName],
+            yesText: L["Common:Actions:Delete"],
+            cancelText: L["Common:Actions:Cancel"]);
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        if (await PageState.DeleteClusterAsync(cluster.Config.ClusterId))
+        {
+            Snackbar.Add(L["Clusters:Messages:Deleted"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task TestClusterAsync(KafkaClusterSummary cluster)
+    {
+        if (await PageState.TestClusterAsync(cluster.Config.ClusterId))
+        {
+            Snackbar.Add(L["Clusters:Messages:TestSucceeded"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task OpenCreateTopicDialogAsync()
+    {
+        if (PageState.SelectedClusterId is null)
+        {
+            return;
+        }
+
+        var parameters = new DialogParameters<CreateKafkaTopicDialog>
+        {
+            { dialog => dialog.ClusterId, PageState.SelectedClusterId }
+        };
+        var dialog = await DialogService.ShowAsync<CreateKafkaTopicDialog>(
+            L["Topics:Dialog:CreateTitle"],
+            parameters,
+            DefaultDialogOptions);
+
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not KafkaTopicCreateRequest request)
+        {
+            return;
+        }
+
+        if (await PageState.CreateTopicAsync(request))
+        {
+            Snackbar.Add(L["Topics:Messages:Created"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task DeleteTopicAsync(KafkaTopicSummary topic)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            L["Topics:Confirm:DeleteTitle"],
+            L["Topics:Confirm:DeleteMessage", topic.TopicName],
+            yesText: L["Common:Actions:Delete"],
+            cancelText: L["Common:Actions:Cancel"]);
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        if (await PageState.DeleteTopicAsync(topic.TopicName))
+        {
+            Snackbar.Add(L["Topics:Messages:Deleted"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task OpenIncreasePartitionsDialogAsync(KafkaTopicSummary topic)
+    {
+        var parameters = new DialogParameters<KafkaPartitionDialog>
+        {
+            { dialog => dialog.Topic, topic }
+        };
+        var dialog = await DialogService.ShowAsync<KafkaPartitionDialog>(
+            L["Topics:Dialog:PartitionsTitle"],
+            parameters,
+            DefaultDialogOptions);
+
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not int increaseTo)
+        {
+            return;
+        }
+
+        if (await PageState.IncreasePartitionsAsync(topic.TopicName, increaseTo))
+        {
+            Snackbar.Add(L["Topics:Messages:PartitionsUpdated"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task OpenRetentionDialogAsync(KafkaTopicSummary topic)
+    {
+        var parameters = new DialogParameters<KafkaRetentionDialog>
+        {
+            { dialog => dialog.Topic, topic }
+        };
+        var dialog = await DialogService.ShowAsync<KafkaRetentionDialog>(
+            L["Topics:Dialog:RetentionTitle"],
+            parameters,
+            DefaultDialogOptions);
+
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not long retentionMs)
+        {
+            return;
+        }
+
+        if (await PageState.UpdateRetentionAsync(topic.TopicName, retentionMs))
+        {
+            Snackbar.Add(L["Topics:Messages:RetentionUpdated"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task CapturePerformanceAsync()
+    {
+        if (await PageState.CapturePerformanceAsync())
+        {
+            Snackbar.Add(L["Performance:Messages:Captured"], Severity.Success);
+        }
+        else
+        {
+            ShowStateError();
+        }
+
+        StateHasChanged();
+    }
+
+    private void ShowStateError()
+    {
+        Snackbar.Add(PageState.ErrorMessage ?? L["Page:Messages:OperationFailed"], Severity.Error);
+    }
+
+    private static DialogOptions DefaultDialogOptions => new()
+    {
+        CloseOnEscapeKey = true,
+        MaxWidth = MaxWidth.Medium,
+        FullWidth = true
+    };
+}

--- a/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor
+++ b/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor
@@ -72,6 +72,7 @@
                                 OnCreate="OpenCreateTopicDialogAsync"
                                 OnRefresh="RefreshAsync"
                                 OnDelete="DeleteTopicAsync"
+                                OnViewMessages="OpenMessagesDialogAsync"
                                 OnIncreasePartitions="OpenIncreasePartitionsDialogAsync"
                                 OnUpdateRetention="OpenRetentionDialogAsync" />
             </MudTabPanel>
@@ -310,6 +311,30 @@
         StateHasChanged();
     }
 
+    private async Task OpenMessagesDialogAsync(KafkaTopicSummary topic)
+    {
+        var batch = await PageState.ReadTopicMessagesAsync(topic.TopicName, 20);
+        if (batch is null)
+        {
+            ShowStateError();
+            StateHasChanged();
+            return;
+        }
+
+        var parameters = new DialogParameters<KafkaMessagesDialog>
+        {
+            { dialog => dialog.Batch, batch }
+        };
+
+        var dialog = await DialogService.ShowAsync<KafkaMessagesDialog>(
+            L["Topics:Dialog:MessagesTitle", topic.TopicName],
+            parameters,
+            MessageDialogOptions);
+
+        await dialog.Result;
+        StateHasChanged();
+    }
+
     private async Task CapturePerformanceAsync()
     {
         if (await PageState.CapturePerformanceAsync())
@@ -333,6 +358,13 @@
     {
         CloseOnEscapeKey = true,
         MaxWidth = MaxWidth.Medium,
+        FullWidth = true
+    };
+
+    private static DialogOptions MessageDialogOptions => new()
+    {
+        CloseOnEscapeKey = true,
+        MaxWidth = MaxWidth.Large,
         FullWidth = true
     };
 }

--- a/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor.css
+++ b/Monica.EventBus.Kafka/Pages/UIEventBusKafkaPage.razor.css
@@ -1,0 +1,75 @@
+.eventbus-kafka-page {
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    padding: 20px;
+}
+
+.page-banner {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px;
+    border-radius: 8px;
+    border: 1px solid var(--mud-palette-lines-default);
+    background: var(--mud-palette-surface);
+}
+
+.page-banner__copy {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.page-banner__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+::deep .page-eyebrow {
+    letter-spacing: 0;
+    text-transform: uppercase;
+    color: var(--mud-palette-text-secondary);
+}
+
+.page-state {
+    flex: 1 1 auto;
+    min-height: 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 28px;
+    border-radius: 8px;
+    border: 1px dashed var(--mud-palette-lines-default);
+    background: color-mix(in srgb, var(--mud-palette-background-gray) 36%, var(--mud-palette-surface));
+}
+
+::deep .eventbus-kafka-tab-panels {
+    padding: 16px;
+}
+
+@media (max-width: 720px) {
+    .eventbus-kafka-page {
+        padding: 14px;
+        gap: 14px;
+    }
+
+    .page-banner {
+        flex-direction: column;
+    }
+
+    .page-banner__actions {
+        justify-content: flex-start;
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaAdminProvider.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaAdminProvider.cs
@@ -1,0 +1,243 @@
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Services.Support;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Providers.ConfluentKafka;
+
+/// <summary>
+/// Confluent Kafka implementation of Kafka console administration operations.
+/// </summary>
+internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOption> options) : IKafkaAdminProvider
+{
+    private ModuleEventBusKafkaOption Option => options.Value;
+
+    public Task TestConnectionAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        using var admin = CreateAdminClient(cluster);
+        var metadata = admin.GetMetadata(Option.AdminRequestTimeout);
+        if (metadata.Brokers.Count == 0)
+        {
+            throw new InvalidOperationException($"Kafka cluster '{cluster.ClusterId}' returned no brokers.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<KafkaBrokerInfo>> ListBrokersAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        using var admin = CreateAdminClient(cluster);
+        var metadata = admin.GetMetadata(Option.AdminRequestTimeout);
+        var brokers = metadata.Brokers
+            .Select(broker => new KafkaBrokerInfo
+            {
+                BrokerId = broker.BrokerId,
+                Host = broker.Host,
+                Port = broker.Port
+            })
+            .OrderBy(broker => broker.BrokerId)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<KafkaBrokerInfo>>(brokers);
+    }
+
+    public async Task<IReadOnlyList<KafkaTopicSummary>> ListTopicsAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        using var admin = CreateAdminClient(cluster);
+        var metadata = admin.GetMetadata(Option.AdminRequestTimeout);
+        var topicNames = metadata.Topics
+            .Where(topic => topic.Error.Code == ErrorCode.NoError)
+            .Select(topic => topic.Topic)
+            .OrderBy(topic => topic, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var retention = await DescribeTopicRetentionsAsync(admin, topicNames, cancellationToken);
+        var topics = metadata.Topics
+            .Where(topic => topic.Error.Code == ErrorCode.NoError)
+            .Select(topic => new KafkaTopicSummary
+            {
+                TopicName = topic.Topic,
+                Partitions = topic.Partitions.Count,
+                ReplicationFactor = topic.Partitions.Count == 0 ? 0 : topic.Partitions.Max(partition => partition.Replicas.Length),
+                IsInternal = topic.Topic.StartsWith("__", StringComparison.Ordinal),
+                RetentionMs = retention.GetValueOrDefault(topic.Topic)
+            })
+            .OrderBy(topic => topic.TopicName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return topics;
+    }
+
+    public async Task CreateTopicAsync(KafkaClusterConfig cluster, KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
+        using var admin = CreateAdminClient(cluster);
+
+        var specification = new TopicSpecification
+        {
+            Name = request.TopicName.Trim(),
+            NumPartitions = Math.Max(1, request.Partitions),
+            ReplicationFactor = Math.Max((short)1, request.ReplicationFactor),
+            Configs = request.RetentionMs is > 0
+                ? new Dictionary<string, string> { ["retention.ms"] = request.RetentionMs.Value.ToString() }
+                : null
+        };
+
+        await admin.CreateTopicsAsync([specification], new CreateTopicsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+    }
+
+    public async Task DeleteTopicAsync(KafkaClusterConfig cluster, string topicName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+        using var admin = CreateAdminClient(cluster);
+        await admin.DeleteTopicsAsync([topicName.Trim()], new DeleteTopicsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+    }
+
+    public async Task IncreasePartitionsAsync(KafkaClusterConfig cluster, KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
+        if (request.IncreaseTo <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Partition count must be greater than zero.");
+        }
+
+        using var admin = CreateAdminClient(cluster);
+        await admin.CreatePartitionsAsync(
+            [
+                new PartitionsSpecification
+                {
+                    Topic = request.TopicName.Trim(),
+                    IncreaseTo = request.IncreaseTo
+                }
+            ],
+            new CreatePartitionsOptions
+            {
+                RequestTimeout = Option.AdminRequestTimeout
+            });
+    }
+
+    public async Task UpdateRetentionAsync(KafkaClusterConfig cluster, KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
+        if (request.RetentionMs <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Retention must be greater than zero.");
+        }
+
+        using var admin = CreateAdminClient(cluster);
+        var resource = new ConfigResource
+        {
+            Type = ResourceType.Topic,
+            Name = request.TopicName.Trim()
+        };
+        var configs = new Dictionary<ConfigResource, List<ConfigEntry>>
+        {
+            [resource] =
+            [
+                new ConfigEntry
+                {
+                    Name = "retention.ms",
+                    Value = request.RetentionMs.ToString(),
+                    IncrementalOperation = AlterConfigOpType.Set
+                }
+            ]
+        };
+
+        await admin.IncrementalAlterConfigsAsync(configs, new IncrementalAlterConfigsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+    }
+
+    public async Task<IReadOnlyList<KafkaConsumerGroupSummary>> ListConsumerGroupsAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        using var admin = CreateAdminClient(cluster);
+        var result = await admin.ListConsumerGroupsAsync(new ListConsumerGroupsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+
+        var groupIds = result.Valid
+            .Select(group => group.GroupId)
+            .Where(groupId => !string.IsNullOrWhiteSpace(groupId))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(groupId => groupId, StringComparer.OrdinalIgnoreCase)
+            .Take(Option.MaxConsumerGroupsToDescribe)
+            .ToList();
+
+        if (groupIds.Count == 0)
+        {
+            return [];
+        }
+
+        var descriptions = await admin.DescribeConsumerGroupsAsync(groupIds, new DescribeConsumerGroupsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+
+        return descriptions.ConsumerGroupDescriptions
+            .Select(group => new KafkaConsumerGroupSummary
+            {
+                GroupId = group.GroupId,
+                State = group.State.ToString(),
+                MemberCount = group.Members.Count,
+                TotalLag = null
+            })
+            .OrderBy(group => group.GroupId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IAdminClient CreateAdminClient(KafkaClusterConfig cluster)
+    {
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' does not expose direct broker credentials to Monica.");
+        }
+
+        return new AdminClientBuilder(KafkaClientConfigFactory.BuildAdminConfig(cluster, Option)).Build();
+    }
+
+    private async Task<Dictionary<string, long?>> DescribeTopicRetentionsAsync(
+        IAdminClient admin,
+        IReadOnlyList<string> topicNames,
+        CancellationToken cancellationToken)
+    {
+        if (topicNames.Count == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            var resources = topicNames.Select(topicName => new ConfigResource
+            {
+                Type = ResourceType.Topic,
+                Name = topicName
+            });
+            var result = await admin.DescribeConfigsAsync(resources, new DescribeConfigsOptions
+            {
+                RequestTimeout = Option.AdminRequestTimeout
+            });
+
+            return result.ToDictionary(
+                item => item.ConfigResource.Name,
+                item => item.Entries.TryGetValue("retention.ms", out var entry) && long.TryParse(entry.Value, out var value)
+                    ? value
+                    : (long?)null,
+                StringComparer.Ordinal);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaMessageReader.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaMessageReader.cs
@@ -1,0 +1,226 @@
+using System.Text;
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Services.Support;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Providers.ConfluentKafka;
+
+/// <summary>
+/// Confluent Kafka implementation of read-only message previews.
+/// </summary>
+internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOption> options) : IKafkaMessageReader
+{
+    private const string SERVICE_KEY = "message-preview";
+    private static readonly UTF8Encoding STRICT_UTF8 = new(false, true);
+
+    private ModuleEventBusKafkaOption Option => options.Value;
+
+    public Task<KafkaTopicMessageBatch> ReadMessagesAsync(
+        KafkaClusterConfig cluster,
+        KafkaTopicMessagesRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
+
+        var maxMessages = Math.Clamp(request.MaxMessages, 1, Math.Max(1, Option.MessagePreviewMaxMessages));
+        using var admin = CreateAdminClient(cluster);
+        using var consumer = CreateConsumer(cluster);
+        var topicName = request.TopicName.Trim();
+        var partitions = ResolvePartitions(admin, topicName);
+        var assignments = BuildAssignments(consumer, partitions, maxMessages);
+        var messages = assignments.Count == 0
+            ? []
+            : ConsumePreview(consumer, assignments, maxMessages, cancellationToken);
+
+        return Task.FromResult(new KafkaTopicMessageBatch
+        {
+            ClusterId = cluster.ClusterId,
+            TopicName = topicName,
+            MaxMessages = maxMessages,
+            CapturedAt = DateTimeOffset.UtcNow,
+            Messages = messages
+        });
+    }
+
+    private IConsumer<byte[], byte[]> CreateConsumer(KafkaClusterConfig cluster)
+    {
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' does not expose direct broker credentials to Monica.");
+        }
+
+        return new ConsumerBuilder<byte[], byte[]>(
+                KafkaClientConfigFactory.BuildReadOnlyConsumerConfig(cluster, Option, SERVICE_KEY))
+            .Build();
+    }
+
+    private IAdminClient CreateAdminClient(KafkaClusterConfig cluster)
+    {
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' does not expose direct broker credentials to Monica.");
+        }
+
+        return new AdminClientBuilder(KafkaClientConfigFactory.BuildAdminConfig(cluster, Option)).Build();
+    }
+
+    private IReadOnlyList<TopicPartition> ResolvePartitions(IAdminClient admin, string topicName)
+    {
+        var metadata = admin.GetMetadata(topicName, Option.AdminRequestTimeout);
+        var topic = metadata.Topics.FirstOrDefault(item =>
+            string.Equals(item.Topic, topicName, StringComparison.Ordinal));
+
+        if (topic is null || topic.Error.Code != ErrorCode.NoError)
+        {
+            throw new InvalidOperationException($"Kafka topic '{topicName}' metadata is not available.");
+        }
+
+        return topic.Partitions
+            .Where(partition => partition.Error.Code == ErrorCode.NoError)
+            .Select(partition => new TopicPartition(topicName, new Partition(partition.PartitionId)))
+            .OrderBy(partition => partition.Partition.Value)
+            .ToList();
+    }
+
+    private IReadOnlyList<TopicPartitionOffset> BuildAssignments(
+        IConsumer<byte[], byte[]> consumer,
+        IReadOnlyList<TopicPartition> partitions,
+        int maxMessages)
+    {
+        var assignments = new List<TopicPartitionOffset>(partitions.Count);
+        foreach (var partition in partitions)
+        {
+            var watermark = consumer.QueryWatermarkOffsets(partition, Option.AdminRequestTimeout);
+            var low = watermark.Low.Value;
+            var high = watermark.High.Value;
+            if (high <= low)
+            {
+                continue;
+            }
+
+            assignments.Add(new TopicPartitionOffset(
+                partition,
+                new Offset(Math.Max(low, high - maxMessages))));
+        }
+
+        return assignments;
+    }
+
+    private IReadOnlyList<KafkaTopicMessageSample> ConsumePreview(
+        IConsumer<byte[], byte[]> consumer,
+        IReadOnlyList<TopicPartitionOffset> assignments,
+        int maxMessages,
+        CancellationToken cancellationToken)
+    {
+        consumer.Assign(assignments);
+
+        var results = new List<KafkaTopicMessageSample>(maxMessages);
+        var highWatermarks = assignments.ToDictionary(
+            assignment => assignment.TopicPartition,
+            assignment => consumer.QueryWatermarkOffsets(assignment.TopicPartition, Option.AdminRequestTimeout).High.Value);
+        var deadline = DateTimeOffset.UtcNow.Add(Option.MessagePreviewTimeout);
+
+        while (results.Count < maxMessages &&
+               DateTimeOffset.UtcNow < deadline &&
+               highWatermarks.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = consumer.Consume(TimeSpan.FromMilliseconds(250));
+            if (result is null)
+            {
+                continue;
+            }
+
+            MarkConsumedPartition(result, highWatermarks);
+            if (result.IsPartitionEOF || result.Message is null)
+            {
+                continue;
+            }
+
+            results.Add(MapMessage(result));
+        }
+
+        consumer.Unassign();
+
+        return results
+            .OrderByDescending(message => message.Timestamp ?? DateTimeOffset.MinValue)
+            .ThenByDescending(message => message.Partition)
+            .ThenByDescending(message => message.Offset)
+            .Take(maxMessages)
+            .ToList();
+    }
+
+    private static void MarkConsumedPartition(
+        ConsumeResult<byte[], byte[]> result,
+        Dictionary<TopicPartition, long> highWatermarks)
+    {
+        if (!highWatermarks.TryGetValue(result.TopicPartition, out var high))
+        {
+            return;
+        }
+
+        if (result.Offset.Value + 1 >= high)
+        {
+            highWatermarks.Remove(result.TopicPartition);
+        }
+    }
+
+    private KafkaTopicMessageSample MapMessage(ConsumeResult<byte[], byte[]> result)
+    {
+        var maxValueBytes = Math.Max(1, Option.MessagePreviewMaxValueBytes);
+        var value = Decode(result.Message.Value, maxValueBytes);
+        var key = Decode(result.Message.Key, maxValueBytes);
+
+        return new KafkaTopicMessageSample
+        {
+            TopicName = result.Topic,
+            Partition = result.Partition.Value,
+            Offset = result.Offset.Value,
+            Timestamp = result.Message.Timestamp.UtcDateTime == DateTime.MinValue
+                ? null
+                : new DateTimeOffset(result.Message.Timestamp.UtcDateTime, TimeSpan.Zero),
+            Key = key.Text,
+            Value = value.Text,
+            ValueEncoding = value.Encoding,
+            ValueSizeBytes = result.Message.Value?.Length ?? 0,
+            IsTruncated = value.IsTruncated,
+            IsTombstone = result.Message.Value is null
+        };
+    }
+
+    private static DecodedPayload Decode(byte[]? payload, int maxBytes)
+    {
+        if (payload is null)
+        {
+            return new DecodedPayload(null, "null", false);
+        }
+
+        var displayBytes = payload.Length > maxBytes
+            ? payload.Take(maxBytes).ToArray()
+            : payload;
+
+        try
+        {
+            return new DecodedPayload(
+                STRICT_UTF8.GetString(displayBytes),
+                "utf-8",
+                displayBytes.Length != payload.Length);
+        }
+        catch (DecoderFallbackException)
+        {
+            return new DecodedPayload(
+                Convert.ToBase64String(displayBytes),
+                "base64",
+                displayBytes.Length != payload.Length);
+        }
+    }
+
+    private sealed record DecodedPayload(string? Text, string Encoding, bool IsTruncated);
+}

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaPerformanceMetricsProvider.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaPerformanceMetricsProvider.cs
@@ -1,0 +1,146 @@
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Services.Support;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Providers.ConfluentKafka;
+
+/// <summary>
+/// Confluent Kafka implementation of read-only offset metric sampling.
+/// </summary>
+internal sealed class ConfluentKafkaPerformanceMetricsProvider(IOptions<ModuleEventBusKafkaOption> options)
+    : IKafkaPerformanceMetricsProvider
+{
+    private ModuleEventBusKafkaOption Option => options.Value;
+
+    public async Task<KafkaPerformanceOffsetTotals> CaptureOffsetTotalsAsync(
+        KafkaClusterConfig cluster,
+        IReadOnlyList<KafkaTopicSummary> topics,
+        IReadOnlyList<KafkaConsumerGroupSummary> consumerGroups,
+        CancellationToken cancellationToken = default)
+    {
+        var partitions = BuildTopicPartitions(topics);
+        if (partitions.Count == 0)
+        {
+            return new KafkaPerformanceOffsetTotals();
+        }
+
+        using var admin = new AdminClientBuilder(KafkaClientConfigFactory.BuildAdminConfig(cluster, Option)).Build();
+        var latestOffsets = await ReadLatestOffsetsAsync(admin, partitions);
+        var consumerOffsets = await ReadConsumerOffsetsAsync(admin, partitions, latestOffsets, consumerGroups, cancellationToken);
+
+        return new KafkaPerformanceOffsetTotals
+        {
+            TotalLogEndOffset = latestOffsets.Values.Sum(),
+            TotalConsumerCommittedOffset = consumerOffsets.TotalCommittedOffset,
+            TotalLag = consumerOffsets.TotalLag
+        };
+    }
+
+    private static IReadOnlyList<TopicPartition> BuildTopicPartitions(IReadOnlyList<KafkaTopicSummary> topics)
+    {
+        return topics
+            .Where(topic => !topic.IsInternal && topic.Partitions > 0)
+            .SelectMany(topic => Enumerable.Range(0, topic.Partitions)
+                .Select(partition => new TopicPartition(topic.TopicName, new Partition(partition))))
+            .ToList();
+    }
+
+    private async Task<Dictionary<TopicPartition, long>> ReadLatestOffsetsAsync(
+        IAdminClient admin,
+        IReadOnlyList<TopicPartition> partitions)
+    {
+        var specs = partitions.Select(partition => new TopicPartitionOffsetSpec
+        {
+            TopicPartition = partition,
+            OffsetSpec = OffsetSpec.Latest()
+        });
+
+        var result = await admin.ListOffsetsAsync(specs, new ListOffsetsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+
+        return result.ResultInfos
+            .Where(info => info.TopicPartitionOffsetError.Error.Code == ErrorCode.NoError &&
+                           info.TopicPartitionOffsetError.Offset.Value >= 0)
+            .ToDictionary(
+                info => info.TopicPartitionOffsetError.TopicPartition,
+                info => info.TopicPartitionOffsetError.Offset.Value);
+    }
+
+    private async Task<ConsumerOffsetTotals> ReadConsumerOffsetsAsync(
+        IAdminClient admin,
+        IReadOnlyList<TopicPartition> partitions,
+        IReadOnlyDictionary<TopicPartition, long> latestOffsets,
+        IReadOnlyList<KafkaConsumerGroupSummary> consumerGroups,
+        CancellationToken cancellationToken)
+    {
+        long committedTotal = 0;
+        long lagTotal = 0;
+        var hasConsumerOffsets = false;
+
+        foreach (var group in consumerGroups.Where(group => !string.IsNullOrWhiteSpace(group.GroupId)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var results = await admin.ListConsumerGroupOffsetsAsync(
+                    [new ConsumerGroupTopicPartitions(group.GroupId, partitions.ToList())],
+                    new ListConsumerGroupOffsetsOptions
+                    {
+                        RequestTimeout = Option.AdminRequestTimeout,
+                        RequireStableOffsets = false
+                    });
+
+                foreach (var partition in results.SelectMany(result => result.Partitions))
+                {
+                    if (partition.Error.Code != ErrorCode.NoError || partition.Offset.Value < 0)
+                    {
+                        continue;
+                    }
+
+                    hasConsumerOffsets = true;
+                    committedTotal += partition.Offset.Value;
+                    lagTotal += CalculateLag(partition, latestOffsets);
+                }
+            }
+            catch (ListConsumerGroupOffsetsException ex)
+            {
+                foreach (var partition in ex.Results.SelectMany(result => result.Partitions))
+                {
+                    if (partition.Error.Code != ErrorCode.NoError || partition.Offset.Value < 0)
+                    {
+                        continue;
+                    }
+
+                    hasConsumerOffsets = true;
+                    committedTotal += partition.Offset.Value;
+                    lagTotal += CalculateLag(partition, latestOffsets);
+                }
+            }
+        }
+
+        if (!hasConsumerOffsets)
+        {
+            return new ConsumerOffsetTotals(null, null);
+        }
+
+        return new ConsumerOffsetTotals(committedTotal, lagTotal);
+    }
+
+    private static long CalculateLag(
+        TopicPartitionOffsetError partition,
+        IReadOnlyDictionary<TopicPartition, long> latestOffsets)
+    {
+        return latestOffsets.TryGetValue(partition.TopicPartition, out var latestOffset)
+            ? Math.Max(0, latestOffset - partition.Offset.Value)
+            : 0;
+    }
+
+    private sealed record ConsumerOffsetTotals(long? TotalCommittedOffset, long? TotalLag);
+}

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusProvider.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusProvider.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Confluent.Kafka;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Monica.Core.JsonSerialization.Abstractions;
+using Monica.EventBus.Abstractions;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Services.Support;
+using Monica.EventBus.Services.Support;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Providers.ConfluentKafka;
+
+/// <summary>
+/// Native Kafka distributed EventBus provider.
+/// </summary>
+public sealed class KafkaEventBusProvider(
+    IServiceScopeFactory serviceScopeFactory,
+    IEventHandlerInvoker eventHandlerInvoker,
+    IEventSubscriptionRegistry subscriptionManager,
+    IKafkaClusterConfigProvider clusterConfigProvider,
+    IJsonSerializerOptionsProvider jsonSerializerOptionsProvider,
+    IOptions<ModuleEventBusKafkaOption> options,
+    string? serviceKey = null)
+    : DistributedEventBusBase(serviceScopeFactory, eventHandlerInvoker, subscriptionManager, serviceKey), IDisposable
+{
+    private readonly Lazy<IProducer<string, string>> _producer = new(() =>
+    {
+        var cluster = clusterConfigProvider.GetDirectEventBusCluster();
+        var config = KafkaClientConfigFactory.BuildProducerConfig(cluster, options.Value);
+        return new ProducerBuilder<string, string>(config).Build();
+    });
+
+    /// <inheritdoc />
+    public override async Task PublishAsync(Type eventType, object eventData, string? topicName = null, CancellationToken cancellationToken = default)
+    {
+        var finalTopicName = ResolveTopicName(eventType, topicName);
+        var payload = JsonSerializer.Serialize(eventData, eventType, jsonSerializerOptionsProvider.SerializerOptions);
+        await _producer.Value.ProduceAsync(
+            finalTopicName,
+            new Message<string, string>
+            {
+                Key = eventType.FullName ?? eventType.Name,
+                Value = payload
+            },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override async Task BulkPublishAsync(Type eventType, IEnumerable<object> eventDataList, string? topicName = null, CancellationToken cancellationToken = default)
+    {
+        var finalTopicName = ResolveTopicName(eventType, topicName);
+        foreach (var eventData in eventDataList)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var payload = JsonSerializer.Serialize(eventData, eventType, jsonSerializerOptionsProvider.SerializerOptions);
+            await _producer.Value.ProduceAsync(
+                finalTopicName,
+                new Message<string, string>
+                {
+                    Key = eventType.FullName ?? eventType.Name,
+                    Value = payload
+                },
+                cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!_producer.IsValueCreated)
+        {
+            return;
+        }
+
+        _producer.Value.Flush(options.Value.ProducerFlushTimeout);
+        _producer.Value.Dispose();
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusSubscriptionHostedService.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusSubscriptionHostedService.cs
@@ -1,0 +1,155 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Confluent.Kafka;
+using Microsoft.Extensions.Options;
+using Monica.Core.HostedService.Models;
+using Monica.Core.JsonSerialization.Abstractions;
+using Monica.Core.Modularity.Models;
+using Monica.Core.ObservableInstance.Abstractions;
+using Monica.EventBus.Abstractions;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Services.Support;
+using Monica.EventBus.Services.Support;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Providers.ConfluentKafka;
+
+/// <summary>
+/// Hosted service that owns Kafka consumers for active distributed EventBus subscriptions.
+/// </summary>
+internal sealed class KafkaEventBusSubscriptionHostedService(
+    IEventSubscriptionRegistry subscriptionManager,
+    IDistributedEventBus eventBus,
+    IObservableInstanceRegistry observableManager,
+    IOptions<ModuleHostedServiceOption> hostedServiceOptions,
+    IKafkaClusterConfigProvider clusterConfigProvider,
+    IJsonSerializerOptionsProvider jsonSerializerOptionsProvider,
+    IOptions<ModuleEventBusKafkaOption> options,
+    string? serviceKey = null)
+    : EventBusSubscriptionHostedServiceBase(
+        subscriptionManager,
+        eventBus,
+        observableManager,
+        hostedServiceOptions,
+        serviceKey)
+{
+    private readonly ConcurrentDictionary<string, TopicConsumer> _consumers = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public override string ServiceName => $"KafkaEventBus{(ServiceKey is null ? string.Empty : $"_{ServiceKey}")}";
+
+    /// <inheritdoc />
+    public override string? ServiceGroupId => nameof(BuiltInModuleKey.EventBus);
+
+    protected override Task CreateExternalSubscriptionForTopicAsync(string topicName, Type eventType, CancellationToken cancellationToken)
+    {
+        var consumer = new TopicConsumer(topicName, eventType, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken));
+        if (!_consumers.TryAdd(topicName, consumer))
+        {
+            return Task.CompletedTask;
+        }
+
+        consumer.Task = Task.Run(() => ConsumeAsync(consumer), CancellationToken.None);
+        RecordState($"Started Kafka consumer for topic {topicName}", HostedServiceState.Running);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task RemoveExternalSubscriptionForTopicAsync(string topicName, CancellationToken cancellationToken)
+    {
+        if (!_consumers.TryRemove(topicName, out var consumer))
+        {
+            return;
+        }
+
+        await StopConsumerAsync(consumer);
+    }
+
+    protected override async Task DisposeExternalSubscriptionsAsync(CancellationToken cancellationToken)
+    {
+        var consumers = _consumers.Values.ToList();
+        _consumers.Clear();
+
+        foreach (var consumer in consumers)
+        {
+            await StopConsumerAsync(consumer);
+        }
+    }
+
+    private async Task StopConsumerAsync(TopicConsumer consumer)
+    {
+        await consumer.CancellationTokenSource.CancelAsync();
+        try
+        {
+            if (consumer.Task is not null)
+            {
+                await consumer.Task;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during unsubscribe and shutdown.
+        }
+        finally
+        {
+            consumer.CancellationTokenSource.Dispose();
+        }
+    }
+
+    private async Task ConsumeAsync(TopicConsumer topicConsumer)
+    {
+        var cluster = clusterConfigProvider.GetDirectEventBusCluster();
+        var consumerConfig = KafkaClientConfigFactory.BuildConsumerConfig(cluster, options.Value, ServiceKey);
+
+        using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
+        consumer.Subscribe(topicConsumer.TopicName);
+
+        while (!topicConsumer.CancellationTokenSource.IsCancellationRequested)
+        {
+            try
+            {
+                var result = consumer.Consume(topicConsumer.CancellationTokenSource.Token);
+                if (result?.Message?.Value is null)
+                {
+                    continue;
+                }
+
+                var eventData = JsonSerializer.Deserialize(
+                    result.Message.Value,
+                    topicConsumer.EventType,
+                    jsonSerializerOptionsProvider.SerializerOptions);
+                if (eventData is null)
+                {
+                    RecordState($"Kafka message on topic {topicConsumer.TopicName} deserialized to null", HostedServiceState.Degraded);
+                    continue;
+                }
+
+                await HandleExternalMessageAsync(
+                    topicConsumer.TopicName,
+                    eventData,
+                    topicConsumer.CancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                RecordState($"Kafka consumer failed for topic {topicConsumer.TopicName}", HostedServiceState.Degraded, ex);
+                await Task.Delay(options.Value.ConsumerErrorBackoff, topicConsumer.CancellationTokenSource.Token);
+            }
+        }
+
+        consumer.Close();
+    }
+
+    private sealed class TopicConsumer(string topicName, Type eventType, CancellationTokenSource cancellationTokenSource)
+    {
+        public string TopicName { get; } = topicName;
+
+        public Type EventType { get; } = eventType;
+
+        public CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
+
+        public Task? Task { get; set; }
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/EfCore/EfCoreKafkaConsoleRepository.cs
+++ b/Monica.EventBus.Kafka/Providers/EfCore/EfCoreKafkaConsoleRepository.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Providers.EfCore;
+
+/// <summary>
+/// EF Core-backed Kafka console repository.
+/// </summary>
+public sealed class EfCoreKafkaConsoleRepository(KafkaConsoleDbContext dbContext) : IKafkaConsoleRepository
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<KafkaClusterConfig>> GetClustersAsync(CancellationToken cancellationToken = default)
+    {
+        var clusters = await dbContext.KafkaClusters
+            .AsNoTracking()
+            .OrderBy(cluster => cluster.DisplayName)
+            .ToListAsync(cancellationToken);
+
+        return clusters.Select(cluster => cluster.ToModel()).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<KafkaClusterConfig?> GetClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.KafkaClusters
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cluster => cluster.ClusterId == clusterId, cancellationToken);
+        return entity?.ToModel();
+    }
+
+    /// <inheritdoc />
+    public async Task UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        var normalized = cluster.Clone().Normalize();
+        var existing = await dbContext.KafkaClusters
+            .FirstOrDefaultAsync(item => item.ClusterId == normalized.ClusterId, cancellationToken);
+
+        if (existing is null)
+        {
+            normalized.CreatedAt = normalized.CreatedAt == default ? DateTimeOffset.UtcNow : normalized.CreatedAt;
+            normalized.UpdatedAt = DateTimeOffset.UtcNow;
+            dbContext.KafkaClusters.Add(KafkaClusterEntity.FromModel(normalized));
+        }
+        else
+        {
+            var updated = KafkaClusterEntity.FromModel(normalized);
+            updated.CreatedAt = existing.CreatedAt;
+            updated.UpdatedAt = DateTimeOffset.UtcNow;
+            dbContext.Entry(existing).CurrentValues.SetValues(updated);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        await dbContext.KafkaClusters
+            .Where(cluster => cluster.ClusterId == clusterId)
+            .ExecuteDeleteAsync(cancellationToken);
+        await dbContext.KafkaPerformanceSnapshots
+            .Where(snapshot => snapshot.ClusterId == clusterId)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task SavePerformanceSnapshotAsync(KafkaPerformanceSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        dbContext.KafkaPerformanceSnapshots.Add(KafkaPerformanceSnapshotEntity.FromModel(snapshot));
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<KafkaPerformanceSnapshot?> GetLatestPerformanceSnapshotAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.KafkaPerformanceSnapshots
+            .AsNoTracking()
+            .Where(snapshot => snapshot.ClusterId == clusterId)
+            .OrderByDescending(snapshot => snapshot.CapturedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+        return entity?.ToModel();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<KafkaPerformanceSnapshot>> GetPerformanceSnapshotsAsync(
+        string clusterId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        var snapshots = await dbContext.KafkaPerformanceSnapshots
+            .AsNoTracking()
+            .Where(snapshot => snapshot.ClusterId == clusterId)
+            .OrderByDescending(snapshot => snapshot.CapturedAt)
+            .Take(Math.Max(1, limit))
+            .ToListAsync(cancellationToken);
+
+        return snapshots
+            .Select(snapshot => snapshot.ToModel())
+            .Reverse()
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task DeletePerformanceSnapshotsOlderThanAsync(DateTimeOffset olderThanUtc, CancellationToken cancellationToken = default)
+    {
+        await dbContext.KafkaPerformanceSnapshots
+            .Where(snapshot => snapshot.CapturedAt < olderThanUtc)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleDbContext.cs
+++ b/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleDbContext.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Monica.DependencyInjection.Abstractions;
+using Monica.Repository.Persistence.Services;
+
+namespace Monica.EventBus.Kafka.Providers.EfCore;
+
+/// <summary>
+/// EF Core DbContext for Kafka console persistence.
+/// </summary>
+public sealed class KafkaConsoleDbContext(
+    DbContextOptions<KafkaConsoleDbContext> options,
+    ICachedServiceProvider serviceProvider)
+    : RepositoryDbContext<KafkaConsoleDbContext>(options, serviceProvider)
+{
+    /// <summary>
+    /// Persisted Kafka clusters.
+    /// </summary>
+    public DbSet<KafkaClusterEntity> KafkaClusters => Set<KafkaClusterEntity>();
+
+    /// <summary>
+    /// Persisted Kafka performance snapshots.
+    /// </summary>
+    public DbSet<KafkaPerformanceSnapshotEntity> KafkaPerformanceSnapshots => Set<KafkaPerformanceSnapshotEntity>();
+
+    protected override void OnModelCreatingExtend(ModelBuilder builder)
+    {
+        base.OnModelCreatingExtend(builder);
+
+        builder.Entity<KafkaClusterEntity>(entity =>
+        {
+            entity.ToTable("mo_eventbus_kafka_clusters");
+            entity.HasKey(cluster => cluster.ClusterId);
+            entity.Property(cluster => cluster.ClusterId).HasMaxLength(128);
+            entity.Property(cluster => cluster.DisplayName).HasMaxLength(256);
+            entity.Property(cluster => cluster.BootstrapServers).HasMaxLength(2048);
+            entity.Property(cluster => cluster.ClientId).HasMaxLength(256);
+            entity.Property(cluster => cluster.SecurityProtocol).HasMaxLength(64);
+            entity.Property(cluster => cluster.SaslMechanism).HasMaxLength(64);
+            entity.Property(cluster => cluster.SaslUsername).HasMaxLength(512);
+            entity.Property(cluster => cluster.SaslPassword).HasMaxLength(2048);
+            entity.Property(cluster => cluster.SslCaLocation).HasMaxLength(2048);
+            entity.Property(cluster => cluster.JmxEndpoint).HasMaxLength(512);
+            entity.Property(cluster => cluster.DaprPubSubName).HasMaxLength(256);
+        });
+
+        builder.Entity<KafkaPerformanceSnapshotEntity>(entity =>
+        {
+            entity.ToTable("mo_eventbus_kafka_performance_snapshots");
+            entity.HasKey(snapshot => snapshot.Id);
+            entity.Property(snapshot => snapshot.ClusterId).HasMaxLength(128);
+            entity.Property(snapshot => snapshot.Message).HasMaxLength(2048);
+            entity.HasIndex(snapshot => new { snapshot.ClusterId, snapshot.CapturedAt });
+        });
+    }
+}

--- a/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleEntities.cs
+++ b/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleEntities.cs
@@ -175,6 +175,26 @@ public sealed class KafkaPerformanceSnapshotEntity
     public long? TotalLag { get; set; }
 
     /// <summary>
+    /// Sum of latest offsets across sampled non-internal topic partitions.
+    /// </summary>
+    public long? TotalLogEndOffset { get; set; }
+
+    /// <summary>
+    /// Sum of committed offsets across sampled consumer groups and non-internal topic partitions.
+    /// </summary>
+    public long? TotalConsumerCommittedOffset { get; set; }
+
+    /// <summary>
+    /// Estimated topic write rate in messages per second.
+    /// </summary>
+    public double? MessageWriteRatePerSecond { get; set; }
+
+    /// <summary>
+    /// Estimated consumer processing rate in messages per second.
+    /// </summary>
+    public double? MessageConsumeRatePerSecond { get; set; }
+
+    /// <summary>
     /// Whether JMX metrics were included.
     /// </summary>
     public bool IncludesJmxMetrics { get; set; }
@@ -197,6 +217,10 @@ public sealed class KafkaPerformanceSnapshotEntity
             TopicCount = TopicCount,
             ConsumerGroupCount = ConsumerGroupCount,
             TotalLag = TotalLag,
+            TotalLogEndOffset = TotalLogEndOffset,
+            TotalConsumerCommittedOffset = TotalConsumerCommittedOffset,
+            MessageWriteRatePerSecond = MessageWriteRatePerSecond,
+            MessageConsumeRatePerSecond = MessageConsumeRatePerSecond,
             IncludesJmxMetrics = IncludesJmxMetrics,
             Message = Message
         };
@@ -215,6 +239,10 @@ public sealed class KafkaPerformanceSnapshotEntity
             TopicCount = model.TopicCount,
             ConsumerGroupCount = model.ConsumerGroupCount,
             TotalLag = model.TotalLag,
+            TotalLogEndOffset = model.TotalLogEndOffset,
+            TotalConsumerCommittedOffset = model.TotalConsumerCommittedOffset,
+            MessageWriteRatePerSecond = model.MessageWriteRatePerSecond,
+            MessageConsumeRatePerSecond = model.MessageConsumeRatePerSecond,
             IncludesJmxMetrics = model.IncludesJmxMetrics,
             Message = model.Message
         };

--- a/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleEntities.cs
+++ b/Monica.EventBus.Kafka/Providers/EfCore/KafkaConsoleEntities.cs
@@ -1,0 +1,222 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Providers.EfCore;
+
+/// <summary>
+/// Persisted Kafka cluster entity.
+/// </summary>
+public sealed class KafkaClusterEntity
+{
+    /// <summary>
+    /// Cluster identifier.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bootstrap server list.
+    /// </summary>
+    public string BootstrapServers { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional client id.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Optional security protocol.
+    /// </summary>
+    public string? SecurityProtocol { get; set; }
+
+    /// <summary>
+    /// Optional SASL mechanism.
+    /// </summary>
+    public string? SaslMechanism { get; set; }
+
+    /// <summary>
+    /// Optional SASL user name.
+    /// </summary>
+    public string? SaslUsername { get; set; }
+
+    /// <summary>
+    /// Optional SASL password.
+    /// </summary>
+    public string? SaslPassword { get; set; }
+
+    /// <summary>
+    /// Optional SSL CA location.
+    /// </summary>
+    public string? SslCaLocation { get; set; }
+
+    /// <summary>
+    /// Optional JMX endpoint.
+    /// </summary>
+    public string? JmxEndpoint { get; set; }
+
+    /// <summary>
+    /// Optional Dapr pub/sub name.
+    /// </summary>
+    public string? DaprPubSubName { get; set; }
+
+    /// <summary>
+    /// Whether the cluster backs Dapr pub/sub.
+    /// </summary>
+    public bool IsDaprBacked { get; set; }
+
+    /// <summary>
+    /// Whether credentials are stored outside Monica.
+    /// </summary>
+    public bool CredentialsManagedExternally { get; set; }
+
+    /// <summary>
+    /// UTC creation time.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// UTC update time.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Converts the entity to a public model.
+    /// </summary>
+    public KafkaClusterConfig ToModel()
+    {
+        return new KafkaClusterConfig
+        {
+            ClusterId = ClusterId,
+            DisplayName = DisplayName,
+            BootstrapServers = BootstrapServers,
+            ClientId = ClientId,
+            SecurityProtocol = SecurityProtocol,
+            SaslMechanism = SaslMechanism,
+            SaslUsername = SaslUsername,
+            SaslPassword = SaslPassword,
+            SslCaLocation = SslCaLocation,
+            JmxEndpoint = JmxEndpoint,
+            DaprPubSubName = DaprPubSubName,
+            IsDaprBacked = IsDaprBacked,
+            CredentialsManagedExternally = CredentialsManagedExternally,
+            CreatedAt = CreatedAt,
+            UpdatedAt = UpdatedAt
+        };
+    }
+
+    /// <summary>
+    /// Converts a public model to an entity.
+    /// </summary>
+    public static KafkaClusterEntity FromModel(KafkaClusterConfig model)
+    {
+        var normalized = model.Clone().Normalize();
+        return new KafkaClusterEntity
+        {
+            ClusterId = normalized.ClusterId,
+            DisplayName = normalized.DisplayName,
+            BootstrapServers = normalized.BootstrapServers,
+            ClientId = normalized.ClientId,
+            SecurityProtocol = normalized.SecurityProtocol,
+            SaslMechanism = normalized.SaslMechanism,
+            SaslUsername = normalized.SaslUsername,
+            SaslPassword = normalized.SaslPassword,
+            SslCaLocation = normalized.SslCaLocation,
+            JmxEndpoint = normalized.JmxEndpoint,
+            DaprPubSubName = normalized.DaprPubSubName,
+            IsDaprBacked = normalized.IsDaprBacked,
+            CredentialsManagedExternally = normalized.CredentialsManagedExternally,
+            CreatedAt = normalized.CreatedAt,
+            UpdatedAt = normalized.UpdatedAt
+        };
+    }
+}
+
+/// <summary>
+/// Persisted Kafka performance snapshot entity.
+/// </summary>
+public sealed class KafkaPerformanceSnapshotEntity
+{
+    /// <summary>
+    /// Entity id.
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Cluster identifier.
+    /// </summary>
+    public string ClusterId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC capture time.
+    /// </summary>
+    public DateTimeOffset CapturedAt { get; set; }
+
+    /// <summary>
+    /// Broker count.
+    /// </summary>
+    public int BrokerCount { get; set; }
+
+    /// <summary>
+    /// Topic count.
+    /// </summary>
+    public int TopicCount { get; set; }
+
+    /// <summary>
+    /// Consumer group count.
+    /// </summary>
+    public int ConsumerGroupCount { get; set; }
+
+    /// <summary>
+    /// Total lag when available.
+    /// </summary>
+    public long? TotalLag { get; set; }
+
+    /// <summary>
+    /// Whether JMX metrics were included.
+    /// </summary>
+    public bool IncludesJmxMetrics { get; set; }
+
+    /// <summary>
+    /// Optional sampling message.
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Converts the entity to a public model.
+    /// </summary>
+    public KafkaPerformanceSnapshot ToModel()
+    {
+        return new KafkaPerformanceSnapshot
+        {
+            ClusterId = ClusterId,
+            CapturedAt = CapturedAt,
+            BrokerCount = BrokerCount,
+            TopicCount = TopicCount,
+            ConsumerGroupCount = ConsumerGroupCount,
+            TotalLag = TotalLag,
+            IncludesJmxMetrics = IncludesJmxMetrics,
+            Message = Message
+        };
+    }
+
+    /// <summary>
+    /// Converts a public model to an entity.
+    /// </summary>
+    public static KafkaPerformanceSnapshotEntity FromModel(KafkaPerformanceSnapshot model)
+    {
+        return new KafkaPerformanceSnapshotEntity
+        {
+            ClusterId = model.ClusterId,
+            CapturedAt = model.CapturedAt,
+            BrokerCount = model.BrokerCount,
+            TopicCount = model.TopicCount,
+            ConsumerGroupCount = model.ConsumerGroupCount,
+            TotalLag = model.TotalLag,
+            IncludesJmxMetrics = model.IncludesJmxMetrics,
+            Message = model.Message
+        };
+    }
+}

--- a/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
+++ b/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
@@ -122,6 +122,10 @@ internal sealed class InMemoryKafkaConsoleRepository : IKafkaConsoleRepository
             TopicCount = snapshot.TopicCount,
             ConsumerGroupCount = snapshot.ConsumerGroupCount,
             TotalLag = snapshot.TotalLag,
+            TotalLogEndOffset = snapshot.TotalLogEndOffset,
+            TotalConsumerCommittedOffset = snapshot.TotalConsumerCommittedOffset,
+            MessageWriteRatePerSecond = snapshot.MessageWriteRatePerSecond,
+            MessageConsumeRatePerSecond = snapshot.MessageConsumeRatePerSecond,
             IncludesJmxMetrics = snapshot.IncludesJmxMetrics,
             Message = snapshot.Message
         };

--- a/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
+++ b/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// In-memory Kafka console repository used when no persistent store is configured.
+/// </summary>
+internal sealed class InMemoryKafkaConsoleRepository : IKafkaConsoleRepository
+{
+    private readonly ConcurrentDictionary<string, KafkaClusterConfig> _clusters = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, List<KafkaPerformanceSnapshot>> _snapshots = new(StringComparer.Ordinal);
+
+    public Task<IReadOnlyList<KafkaClusterConfig>> GetClustersAsync(CancellationToken cancellationToken = default)
+    {
+        var clusters = _clusters.Values
+            .Select(cluster => cluster.Clone())
+            .OrderBy(cluster => cluster.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<KafkaClusterConfig>>(clusters);
+    }
+
+    public Task<KafkaClusterConfig?> GetClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(
+            _clusters.TryGetValue(clusterId, out var cluster)
+                ? cluster.Clone()
+                : null);
+    }
+
+    public Task UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        var normalized = cluster.Clone().Normalize();
+        normalized.UpdatedAt = DateTimeOffset.UtcNow;
+        normalized.CreatedAt = _clusters.TryGetValue(normalized.ClusterId, out var existing)
+            ? existing.CreatedAt
+            : normalized.CreatedAt;
+        _clusters[normalized.ClusterId] = normalized;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        _clusters.TryRemove(clusterId, out _);
+        _snapshots.TryRemove(clusterId, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task SavePerformanceSnapshotAsync(KafkaPerformanceSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        var list = _snapshots.GetOrAdd(snapshot.ClusterId, _ => []);
+        lock (list)
+        {
+            list.Add(CloneSnapshot(snapshot));
+            if (list.Count > 500)
+            {
+                list.RemoveRange(0, list.Count - 500);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<KafkaPerformanceSnapshot?> GetLatestPerformanceSnapshotAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        if (!_snapshots.TryGetValue(clusterId, out var list))
+        {
+            return Task.FromResult<KafkaPerformanceSnapshot?>(null);
+        }
+
+        lock (list)
+        {
+            return Task.FromResult(list.OrderBy(snapshot => snapshot.CapturedAt).LastOrDefault() is { } snapshot
+                ? CloneSnapshot(snapshot)
+                : null);
+        }
+    }
+
+    public Task<IReadOnlyList<KafkaPerformanceSnapshot>> GetPerformanceSnapshotsAsync(
+        string clusterId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_snapshots.TryGetValue(clusterId, out var list))
+        {
+            return Task.FromResult<IReadOnlyList<KafkaPerformanceSnapshot>>([]);
+        }
+
+        lock (list)
+        {
+            var snapshots = list
+                .OrderByDescending(snapshot => snapshot.CapturedAt)
+                .Take(Math.Max(1, limit))
+                .OrderBy(snapshot => snapshot.CapturedAt)
+                .Select(CloneSnapshot)
+                .ToList();
+            return Task.FromResult<IReadOnlyList<KafkaPerformanceSnapshot>>(snapshots);
+        }
+    }
+
+    public Task DeletePerformanceSnapshotsOlderThanAsync(DateTimeOffset olderThanUtc, CancellationToken cancellationToken = default)
+    {
+        foreach (var (_, list) in _snapshots)
+        {
+            lock (list)
+            {
+                list.RemoveAll(snapshot => snapshot.CapturedAt < olderThanUtc);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static KafkaPerformanceSnapshot CloneSnapshot(KafkaPerformanceSnapshot snapshot)
+    {
+        return new KafkaPerformanceSnapshot
+        {
+            ClusterId = snapshot.ClusterId,
+            CapturedAt = snapshot.CapturedAt,
+            BrokerCount = snapshot.BrokerCount,
+            TopicCount = snapshot.TopicCount,
+            ConsumerGroupCount = snapshot.ConsumerGroupCount,
+            TotalLag = snapshot.TotalLag,
+            IncludesJmxMetrics = snapshot.IncludesJmxMetrics,
+            Message = snapshot.Message
+        };
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaClusterConfigProvider.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaClusterConfigProvider.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Resolves cluster configuration used by the direct Kafka EventBus provider.
+/// </summary>
+internal sealed class KafkaClusterConfigProvider(IOptions<ModuleEventBusKafkaOption> options) : IKafkaClusterConfigProvider
+{
+    public KafkaClusterConfig GetDirectEventBusCluster()
+    {
+        var cluster = options.Value.DirectEventBusCluster;
+        if (cluster is null)
+        {
+            throw new InvalidOperationException(
+                "The native Kafka EventBus provider is enabled, but no direct Kafka cluster has been configured.");
+        }
+
+        return cluster.Clone().Normalize();
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaClusterService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaClusterService.cs
@@ -1,0 +1,147 @@
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Microsoft.Extensions.Options;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Coordinates configured Kafka clusters and direct broker probes.
+/// </summary>
+public sealed class KafkaClusterService(
+    IKafkaConsoleRepository repository,
+    IKafkaAdminProvider adminProvider,
+    IOptions<ModuleEventBusKafkaOption> options)
+{
+    public async Task<IReadOnlyList<KafkaClusterSummary>> ListClustersAsync(CancellationToken cancellationToken = default)
+    {
+        var clusters = await GetEffectiveClustersAsync(cancellationToken);
+        var summaries = new List<KafkaClusterSummary>(clusters.Count);
+
+        foreach (var cluster in clusters)
+        {
+            summaries.Add(await BuildSummaryAsync(cluster, refreshBrokerMetadata: false, cancellationToken));
+        }
+
+        return summaries
+            .OrderBy(summary => summary.Config.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<KafkaClusterConfig> GetRequiredClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clusterId);
+
+        var clusters = await GetEffectiveClustersAsync(cancellationToken);
+        return clusters.FirstOrDefault(cluster => string.Equals(cluster.ClusterId, clusterId, StringComparison.Ordinal))
+               ?? throw new KeyNotFoundException($"Kafka cluster '{clusterId}' was not found.");
+    }
+
+    public async Task<KafkaClusterSummary> UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        var normalized = NormalizeForPersistence(cluster);
+        await repository.UpsertClusterAsync(normalized, cancellationToken);
+        return await BuildSummaryAsync(normalized, refreshBrokerMetadata: false, cancellationToken);
+    }
+
+    public Task DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clusterId);
+        return repository.DeleteClusterAsync(clusterId.Trim(), cancellationToken);
+    }
+
+    public async Task<KafkaClusterSummary> TestConnectionAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetRequiredClusterAsync(clusterId, cancellationToken);
+        await adminProvider.TestConnectionAsync(cluster, cancellationToken);
+        return await BuildSummaryAsync(cluster, refreshBrokerMetadata: true, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<KafkaClusterConfig>> GetEffectiveClustersAsync(CancellationToken cancellationToken = default)
+    {
+        var clusters = new Dictionary<string, KafkaClusterConfig>(StringComparer.Ordinal);
+
+        foreach (var configuredCluster in options.Value.ConfiguredClusters)
+        {
+            var normalized = configuredCluster.Clone().Normalize();
+            clusters[normalized.ClusterId] = normalized;
+        }
+
+        if (options.Value.DirectEventBusCluster is not null)
+        {
+            var directCluster = options.Value.DirectEventBusCluster.Clone().Normalize();
+            clusters[directCluster.ClusterId] = directCluster;
+        }
+
+        foreach (var persistedCluster in await repository.GetClustersAsync(cancellationToken))
+        {
+            var normalized = persistedCluster.Clone().Normalize();
+            clusters[normalized.ClusterId] = normalized;
+        }
+
+        return clusters.Values
+            .OrderBy(cluster => cluster.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task<KafkaClusterSummary> BuildSummaryAsync(
+        KafkaClusterConfig cluster,
+        bool refreshBrokerMetadata,
+        CancellationToken cancellationToken)
+    {
+        var summary = new KafkaClusterSummary
+        {
+            Config = cluster.Clone().Normalize(),
+            CapturedAt = DateTimeOffset.UtcNow
+        };
+
+        if (!summary.Config.HasDirectKafkaAccess)
+        {
+            summary.ErrorMessage = summary.Config.IsDaprBacked
+                ? "Kafka broker credentials are managed outside Monica; direct admin operations are disabled."
+                : "Kafka bootstrap servers or credentials are not available for direct admin operations.";
+            return summary;
+        }
+
+        if (!refreshBrokerMetadata)
+        {
+            return summary;
+        }
+
+        try
+        {
+            var brokers = await adminProvider.ListBrokersAsync(summary.Config, cancellationToken);
+            var topics = await adminProvider.ListTopicsAsync(summary.Config, cancellationToken);
+            var groups = await adminProvider.ListConsumerGroupsAsync(summary.Config, cancellationToken);
+
+            summary.IsReachable = brokers.Count > 0;
+            summary.BrokerCount = brokers.Count;
+            summary.TopicCount = topics.Count;
+            summary.ConsumerGroupCount = groups.Count;
+        }
+        catch (Exception ex)
+        {
+            summary.IsReachable = false;
+            summary.ErrorMessage = ex.Message;
+        }
+
+        return summary;
+    }
+
+    private static KafkaClusterConfig NormalizeForPersistence(KafkaClusterConfig cluster)
+    {
+        var normalized = cluster.Clone().Normalize();
+        if (string.IsNullOrWhiteSpace(normalized.DisplayName))
+        {
+            throw new ArgumentException("Kafka cluster display name is required.", nameof(cluster));
+        }
+
+        if (string.IsNullOrWhiteSpace(normalized.BootstrapServers) && !normalized.CredentialsManagedExternally)
+        {
+            throw new ArgumentException("Kafka bootstrap servers are required when credentials are managed by Monica.", nameof(cluster));
+        }
+
+        normalized.UpdatedAt = DateTimeOffset.UtcNow;
+        return normalized;
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaConsumerGroupService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaConsumerGroupService.cs
@@ -1,0 +1,26 @@
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Coordinates Kafka consumer group inspection use cases.
+/// </summary>
+public sealed class KafkaConsumerGroupService(
+    KafkaClusterService clusterService,
+    IKafkaAdminProvider adminProvider)
+{
+    public async Task<IReadOnlyList<KafkaConsumerGroupSummary>> ListConsumerGroupsAsync(
+        string clusterId,
+        CancellationToken cancellationToken = default)
+    {
+        var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' is visible but direct consumer group access is not configured.");
+        }
+
+        return await adminProvider.ListConsumerGroupsAsync(cluster, cancellationToken);
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaDashboardService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaDashboardService.cs
@@ -1,0 +1,65 @@
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Builds dashboard aggregates for the selected Kafka cluster.
+/// </summary>
+public sealed class KafkaDashboardService(
+    KafkaIntegrationService integrationService,
+    KafkaClusterService clusterService,
+    KafkaPerformanceService performanceService)
+{
+    public async Task<KafkaDashboardSnapshot> GetDashboardAsync(string? clusterId = null, CancellationToken cancellationToken = default)
+    {
+        var integration = await integrationService.GetSnapshotAsync(cancellationToken);
+        var clusters = await clusterService.ListClustersAsync(cancellationToken);
+        var selectedCluster = ResolveSelectedCluster(clusters, clusterId, integration.PrimaryClusterId);
+        var latestPerformance = selectedCluster is null
+            ? null
+            : await performanceService.GetLatestAsync(selectedCluster.Config.ClusterId, cancellationToken);
+
+        return new KafkaDashboardSnapshot
+        {
+            Integration = integration,
+            SelectedCluster = selectedCluster,
+            LatestPerformance = latestPerformance,
+            BrokerCount = ResolveCount(selectedCluster?.BrokerCount, latestPerformance?.BrokerCount),
+            TopicCount = ResolveCount(selectedCluster?.TopicCount, latestPerformance?.TopicCount),
+            ConsumerGroupCount = ResolveCount(selectedCluster?.ConsumerGroupCount, latestPerformance?.ConsumerGroupCount)
+        };
+    }
+
+    private static int ResolveCount(int? liveCount, int? sampledCount)
+    {
+        return liveCount is > 0 ? liveCount.Value : sampledCount.GetValueOrDefault();
+    }
+
+    private static KafkaClusterSummary? ResolveSelectedCluster(
+        IReadOnlyList<KafkaClusterSummary> clusters,
+        string? requestedClusterId,
+        string? primaryClusterId)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedClusterId))
+        {
+            var requested = clusters.FirstOrDefault(cluster =>
+                string.Equals(cluster.Config.ClusterId, requestedClusterId, StringComparison.Ordinal));
+            if (requested is not null)
+            {
+                return requested;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(primaryClusterId))
+        {
+            var primary = clusters.FirstOrDefault(cluster =>
+                string.Equals(cluster.Config.ClusterId, primaryClusterId, StringComparison.Ordinal));
+            if (primary is not null)
+            {
+                return primary;
+            }
+        }
+
+        return clusters.FirstOrDefault();
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaIntegrationService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaIntegrationService.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.EventBus.Kafka.Providers.ConfluentKafka;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Builds Kafka integration status snapshots for direct and Dapr-backed configurations.
+/// </summary>
+public sealed class KafkaIntegrationService(
+    IServiceProvider serviceProvider,
+    KafkaClusterService clusterService,
+    IOptions<ModuleEventBusKafkaOption> options)
+{
+    public async Task<KafkaIntegrationSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var clusters = await clusterService.GetEffectiveClustersAsync(cancellationToken);
+        var activeProvider = serviceProvider.GetService<IDistributedEventBus>();
+        var primaryCluster = ResolvePrimaryCluster(clusters);
+        var mode = ResolveMode(activeProvider, primaryCluster);
+
+        return new KafkaIntegrationSnapshot
+        {
+            Mode = mode,
+            ActiveProviderName = ResolveProviderName(activeProvider),
+            DaprPubSubName = primaryCluster?.DaprPubSubName ?? options.Value.DaprPubSubName,
+            PrimaryClusterId = primaryCluster?.ClusterId,
+            Capabilities = ResolveCapabilities(mode, primaryCluster),
+            Messages = BuildMessages(mode, primaryCluster)
+        };
+    }
+
+    private KafkaClusterConfig? ResolvePrimaryCluster(IReadOnlyList<KafkaClusterConfig> clusters)
+    {
+        var option = options.Value;
+        if (!string.IsNullOrWhiteSpace(option.PrimaryClusterId))
+        {
+            var configuredPrimary = clusters.FirstOrDefault(cluster =>
+                string.Equals(cluster.ClusterId, option.PrimaryClusterId, StringComparison.Ordinal));
+            if (configuredPrimary is not null)
+            {
+                return configuredPrimary;
+            }
+        }
+
+        if (option.DirectEventBusCluster is not null)
+        {
+            return option.DirectEventBusCluster.Clone().Normalize();
+        }
+
+        return clusters.FirstOrDefault(cluster => cluster.IsDaprBacked) ?? clusters.FirstOrDefault();
+    }
+
+    private KafkaIntegrationMode ResolveMode(IDistributedEventBus? activeProvider, KafkaClusterConfig? primaryCluster)
+    {
+        if (activeProvider is KafkaEventBusProvider || options.Value.DirectEventBusCluster is not null)
+        {
+            return KafkaIntegrationMode.DirectKafka;
+        }
+
+        if (IsDaprProvider(activeProvider))
+        {
+            return primaryCluster?.IsDaprBacked == true
+                ? KafkaIntegrationMode.DaprKafka
+                : KafkaIntegrationMode.DaprNonKafka;
+        }
+
+        return primaryCluster is null ? KafkaIntegrationMode.NotConfigured : KafkaIntegrationMode.Unknown;
+    }
+
+    private static string ResolveProviderName(IDistributedEventBus? activeProvider)
+    {
+        if (activeProvider is null)
+        {
+            return "Not configured";
+        }
+
+        return activeProvider switch
+        {
+            KafkaEventBusProvider => "Kafka",
+            _ when IsDaprProvider(activeProvider) => "Dapr",
+            _ => activeProvider.GetType().Name
+        };
+    }
+
+    private static KafkaConsoleCapabilities ResolveCapabilities(KafkaIntegrationMode mode, KafkaClusterConfig? primaryCluster)
+    {
+        var capabilities = mode is KafkaIntegrationMode.DirectKafka or KafkaIntegrationMode.DaprKafka
+            ? KafkaConsoleCapabilities.PublishSubscribe
+            : KafkaConsoleCapabilities.None;
+
+        if (primaryCluster?.HasDirectKafkaAccess == true)
+        {
+            capabilities |= KafkaConsoleCapabilities.TopicAdmin |
+                            KafkaConsoleCapabilities.ConsumerGroups |
+                            KafkaConsoleCapabilities.PerformanceSampling;
+        }
+
+        if (!string.IsNullOrWhiteSpace(primaryCluster?.JmxEndpoint))
+        {
+            capabilities |= KafkaConsoleCapabilities.JmxMetrics;
+        }
+
+        return capabilities;
+    }
+
+    private static IReadOnlyList<string> BuildMessages(KafkaIntegrationMode mode, KafkaClusterConfig? primaryCluster)
+    {
+        var messages = new List<string>();
+
+        if (mode == KafkaIntegrationMode.NotConfigured)
+        {
+            messages.Add("No Kafka integration has been configured.");
+        }
+        else if (mode == KafkaIntegrationMode.DaprKafka)
+        {
+            messages.Add("Dapr remains the active EventBus provider; Kafka is visible as the backing broker integration.");
+        }
+        else if (mode == KafkaIntegrationMode.DaprNonKafka)
+        {
+            messages.Add("Dapr is the active EventBus provider, but no Kafka-backed Dapr pub/sub component is declared.");
+        }
+
+        if (primaryCluster is not null && !primaryCluster.HasDirectKafkaAccess)
+        {
+            messages.Add("Direct Kafka administration is unavailable because broker access is not configured in Monica.");
+        }
+
+        return messages;
+    }
+
+    private static bool IsDaprProvider(IDistributedEventBus? activeProvider)
+    {
+        return activeProvider?.GetType().FullName?.Contains("Dapr", StringComparison.OrdinalIgnoreCase) == true;
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Options;
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Captures and reads Kafka performance snapshots used by the console.
+/// </summary>
+public sealed class KafkaPerformanceService(
+    KafkaClusterService clusterService,
+    IKafkaAdminProvider adminProvider,
+    IKafkaConsoleRepository repository,
+    IOptions<ModuleEventBusKafkaOption> options)
+{
+    public async Task<KafkaPerformanceSnapshot?> GetLatestAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clusterId);
+        return await repository.GetLatestPerformanceSnapshotAsync(clusterId.Trim(), cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<KafkaPerformanceSnapshot>> GetHistoryAsync(
+        string clusterId,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clusterId);
+        return await repository.GetPerformanceSnapshotsAsync(
+            clusterId.Trim(),
+            limit.GetValueOrDefault(options.Value.PerformanceHistoryLimit),
+            cancellationToken);
+    }
+
+    public async Task<KafkaPerformanceSnapshot> CaptureAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
+        var snapshot = new KafkaPerformanceSnapshot
+        {
+            ClusterId = cluster.ClusterId,
+            CapturedAt = DateTimeOffset.UtcNow,
+            IncludesJmxMetrics = !string.IsNullOrWhiteSpace(cluster.JmxEndpoint)
+        };
+
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            snapshot.Message = "Direct Kafka access is not configured; performance sampling is limited to configuration visibility.";
+            await SaveSnapshotAsync(snapshot, cancellationToken);
+            return snapshot;
+        }
+
+        try
+        {
+            var brokers = await adminProvider.ListBrokersAsync(cluster, cancellationToken);
+            var topics = await adminProvider.ListTopicsAsync(cluster, cancellationToken);
+            var groups = await adminProvider.ListConsumerGroupsAsync(cluster, cancellationToken);
+
+            snapshot.BrokerCount = brokers.Count;
+            snapshot.TopicCount = topics.Count;
+            snapshot.ConsumerGroupCount = groups.Count;
+            snapshot.TotalLag = groups.Any(group => group.TotalLag.HasValue)
+                ? groups.Sum(group => group.TotalLag.GetValueOrDefault())
+                : null;
+        }
+        catch (Exception ex)
+        {
+            snapshot.Message = ex.Message;
+        }
+
+        await SaveSnapshotAsync(snapshot, cancellationToken);
+        return snapshot;
+    }
+
+    private async Task SaveSnapshotAsync(KafkaPerformanceSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        await repository.SavePerformanceSnapshotAsync(snapshot, cancellationToken);
+        if (options.Value.PerformanceSnapshotRetention > TimeSpan.Zero)
+        {
+            var cutoff = DateTimeOffset.UtcNow.Subtract(options.Value.PerformanceSnapshotRetention);
+            await repository.DeletePerformanceSnapshotsOlderThanAsync(cutoff, cancellationToken);
+        }
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
@@ -11,6 +11,7 @@ namespace Monica.EventBus.Kafka.Services;
 public sealed class KafkaPerformanceService(
     KafkaClusterService clusterService,
     IKafkaAdminProvider adminProvider,
+    IKafkaPerformanceMetricsProvider metricsProvider,
     IKafkaConsoleRepository repository,
     IOptions<ModuleEventBusKafkaOption> options)
 {
@@ -35,6 +36,7 @@ public sealed class KafkaPerformanceService(
     public async Task<KafkaPerformanceSnapshot> CaptureAsync(string clusterId, CancellationToken cancellationToken = default)
     {
         var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
+        var previous = await repository.GetLatestPerformanceSnapshotAsync(cluster.ClusterId, cancellationToken);
         var snapshot = new KafkaPerformanceSnapshot
         {
             ClusterId = cluster.ClusterId,
@@ -58,9 +60,12 @@ public sealed class KafkaPerformanceService(
             snapshot.BrokerCount = brokers.Count;
             snapshot.TopicCount = topics.Count;
             snapshot.ConsumerGroupCount = groups.Count;
-            snapshot.TotalLag = groups.Any(group => group.TotalLag.HasValue)
-                ? groups.Sum(group => group.TotalLag.GetValueOrDefault())
-                : null;
+
+            var offsetTotals = await metricsProvider.CaptureOffsetTotalsAsync(cluster, topics, groups, cancellationToken);
+            snapshot.TotalLag = offsetTotals.TotalLag;
+            snapshot.TotalLogEndOffset = offsetTotals.TotalLogEndOffset;
+            snapshot.TotalConsumerCommittedOffset = offsetTotals.TotalConsumerCommittedOffset;
+            ApplyRates(snapshot, previous);
         }
         catch (Exception ex)
         {
@@ -69,6 +74,39 @@ public sealed class KafkaPerformanceService(
 
         await SaveSnapshotAsync(snapshot, cancellationToken);
         return snapshot;
+    }
+
+    private static void ApplyRates(KafkaPerformanceSnapshot current, KafkaPerformanceSnapshot? previous)
+    {
+        if (previous is null)
+        {
+            return;
+        }
+
+        var elapsedSeconds = (current.CapturedAt - previous.CapturedAt).TotalSeconds;
+        if (elapsedSeconds <= 0)
+        {
+            return;
+        }
+
+        current.MessageWriteRatePerSecond = CalculateRate(
+            previous.TotalLogEndOffset,
+            current.TotalLogEndOffset,
+            elapsedSeconds);
+        current.MessageConsumeRatePerSecond = CalculateRate(
+            previous.TotalConsumerCommittedOffset,
+            current.TotalConsumerCommittedOffset,
+            elapsedSeconds);
+    }
+
+    private static double? CalculateRate(long? previous, long? current, double elapsedSeconds)
+    {
+        if (!previous.HasValue || !current.HasValue || current.Value < previous.Value)
+        {
+            return null;
+        }
+
+        return (current.Value - previous.Value) / elapsedSeconds;
     }
 
     private async Task SaveSnapshotAsync(KafkaPerformanceSnapshot snapshot, CancellationToken cancellationToken)

--- a/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
@@ -8,7 +8,8 @@ namespace Monica.EventBus.Kafka.Services;
 /// </summary>
 public sealed class KafkaTopicService(
     KafkaClusterService clusterService,
-    IKafkaAdminProvider adminProvider)
+    IKafkaAdminProvider adminProvider,
+    IKafkaMessageReader messageReader)
 {
     public async Task<IReadOnlyList<KafkaTopicSummary>> ListTopicsAsync(string clusterId, CancellationToken cancellationToken = default)
     {
@@ -38,6 +39,12 @@ public sealed class KafkaTopicService(
     {
         var cluster = await GetAdminClusterAsync(request.ClusterId, cancellationToken);
         await adminProvider.UpdateRetentionAsync(cluster, request, cancellationToken);
+    }
+
+    public async Task<KafkaTopicMessageBatch> ReadMessagesAsync(KafkaTopicMessagesRequest request, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(request.ClusterId, cancellationToken);
+        return await messageReader.ReadMessagesAsync(cluster, request, cancellationToken);
     }
 
     private async Task<KafkaClusterConfig> GetAdminClusterAsync(string clusterId, CancellationToken cancellationToken)

--- a/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
@@ -1,0 +1,54 @@
+using Monica.EventBus.Kafka.Abstractions;
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Coordinates Kafka topic administration use cases.
+/// </summary>
+public sealed class KafkaTopicService(
+    KafkaClusterService clusterService,
+    IKafkaAdminProvider adminProvider)
+{
+    public async Task<IReadOnlyList<KafkaTopicSummary>> ListTopicsAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(clusterId, cancellationToken);
+        return await adminProvider.ListTopicsAsync(cluster, cancellationToken);
+    }
+
+    public async Task CreateTopicAsync(KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(request.ClusterId, cancellationToken);
+        await adminProvider.CreateTopicAsync(cluster, request, cancellationToken);
+    }
+
+    public async Task DeleteTopicAsync(string clusterId, string topicName, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(clusterId, cancellationToken);
+        await adminProvider.DeleteTopicAsync(cluster, topicName, cancellationToken);
+    }
+
+    public async Task IncreasePartitionsAsync(KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(request.ClusterId, cancellationToken);
+        await adminProvider.IncreasePartitionsAsync(cluster, request, cancellationToken);
+    }
+
+    public async Task UpdateRetentionAsync(KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetAdminClusterAsync(request.ClusterId, cancellationToken);
+        await adminProvider.UpdateRetentionAsync(cluster, request, cancellationToken);
+    }
+
+    private async Task<KafkaClusterConfig> GetAdminClusterAsync(string clusterId, CancellationToken cancellationToken)
+    {
+        var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' is visible but direct admin access is not configured.");
+        }
+
+        return cluster;
+    }
+}

--- a/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
+++ b/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
@@ -38,6 +38,20 @@ internal static class KafkaClientConfigFactory
         return config;
     }
 
+    public static ConsumerConfig BuildReadOnlyConsumerConfig(KafkaClusterConfig cluster, ModuleEventBusKafkaOption option, string serviceKey)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = $"{BuildConsumerGroupId(option, serviceKey)}-{Guid.NewGuid():N}",
+            AutoOffsetReset = AutoOffsetReset.Latest,
+            EnableAutoCommit = false,
+            EnableAutoOffsetStore = false,
+            AllowAutoCreateTopics = false
+        };
+        ApplyCommon(config, cluster, option);
+        return config;
+    }
+
     private static void ApplyCommon(ClientConfig config, KafkaClusterConfig cluster, ModuleEventBusKafkaOption option)
     {
         var normalized = cluster.Clone().Normalize();

--- a/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
+++ b/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
@@ -1,0 +1,96 @@
+using Confluent.Kafka;
+using Monica.EventBus.Kafka.Models;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services.Support;
+
+/// <summary>
+/// Builds Confluent Kafka client configuration from Monica Kafka cluster models.
+/// </summary>
+internal static class KafkaClientConfigFactory
+{
+    public static AdminClientConfig BuildAdminConfig(KafkaClusterConfig cluster, ModuleEventBusKafkaOption option)
+    {
+        var config = new AdminClientConfig();
+        ApplyCommon(config, cluster, option);
+        return config;
+    }
+
+    public static ProducerConfig BuildProducerConfig(KafkaClusterConfig cluster, ModuleEventBusKafkaOption option)
+    {
+        var config = new ProducerConfig
+        {
+            Acks = Acks.All
+        };
+        ApplyCommon(config, cluster, option);
+        return config;
+    }
+
+    public static ConsumerConfig BuildConsumerConfig(KafkaClusterConfig cluster, ModuleEventBusKafkaOption option, string? serviceKey)
+    {
+        var config = new ConsumerConfig
+        {
+            GroupId = BuildConsumerGroupId(option, serviceKey),
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true
+        };
+        ApplyCommon(config, cluster, option);
+        return config;
+    }
+
+    private static void ApplyCommon(ClientConfig config, KafkaClusterConfig cluster, ModuleEventBusKafkaOption option)
+    {
+        var normalized = cluster.Clone().Normalize();
+        if (string.IsNullOrWhiteSpace(normalized.BootstrapServers))
+        {
+            throw new InvalidOperationException($"Kafka cluster '{normalized.ClusterId}' does not define bootstrap servers.");
+        }
+
+        config.BootstrapServers = normalized.BootstrapServers;
+        config.ClientId = normalized.ClientId ?? option.ClientId;
+        config.SocketTimeoutMs = (int)option.AdminRequestTimeout.TotalMilliseconds;
+
+        if (TryParseEnum<SecurityProtocol>(normalized.SecurityProtocol, out var securityProtocol))
+        {
+            config.SecurityProtocol = securityProtocol;
+        }
+
+        if (TryParseEnum<SaslMechanism>(normalized.SaslMechanism, out var saslMechanism))
+        {
+            config.SaslMechanism = saslMechanism;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.SaslUsername))
+        {
+            config.SaslUsername = normalized.SaslUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.SaslPassword))
+        {
+            config.SaslPassword = normalized.SaslPassword;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalized.SslCaLocation))
+        {
+            config.SslCaLocation = normalized.SslCaLocation;
+        }
+    }
+
+    private static string BuildConsumerGroupId(ModuleEventBusKafkaOption option, string? serviceKey)
+    {
+        return string.IsNullOrWhiteSpace(serviceKey)
+            ? option.ConsumerGroupId
+            : $"{option.ConsumerGroupId}-{serviceKey}";
+    }
+
+    private static bool TryParseEnum<TEnum>(string? value, out TEnum result) where TEnum : struct
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            result = default;
+            return false;
+        }
+
+        return Enum.TryParse(value, ignoreCase: true, out result);
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaClustersTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaClustersTab.razor
@@ -1,0 +1,143 @@
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudStack Spacing="3">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+        <MudText Typo="Typo.h6">@L["Clusters:Title"]</MudText>
+        <MudStack Row="true" Spacing="1">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       Disabled="@State.IsBusy"
+                       OnClick="OnRefresh">
+                @L["Common:Actions:Refresh"]
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       Disabled="@State.IsBusy"
+                       OnClick="OnCreate">
+                @L["Clusters:Actions:New"]
+            </MudButton>
+        </MudStack>
+    </MudStack>
+
+    @if (State.Clusters.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            @L["Clusters:Empty"]
+        </MudAlert>
+    }
+    else
+    {
+        <MudTable T="KafkaClusterSummary" Items="@State.Clusters" Dense="true" Hover="true" Bordered="false">
+            <HeaderContent>
+                <MudTh>@L["Clusters:Columns:Name"]</MudTh>
+                <MudTh>@L["Clusters:Columns:Bootstrap"]</MudTh>
+                <MudTh>@L["Clusters:Columns:Mode"]</MudTh>
+                <MudTh>@L["Clusters:Columns:Status"]</MudTh>
+                <MudTh>@L["Clusters:Columns:Actions"]</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="@L["Clusters:Columns:Name"]">
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.body2">@context.Config.DisplayName</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Config.ClusterId</MudText>
+                    </MudStack>
+                </MudTd>
+                <MudTd DataLabel="@L["Clusters:Columns:Bootstrap"]">@GetBootstrapText(context)</MudTd>
+                <MudTd DataLabel="@L["Clusters:Columns:Mode"]">
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetClusterModeColor(context)">
+                        @GetClusterMode(context)
+                    </MudChip>
+                </MudTd>
+                <MudTd DataLabel="@L["Clusters:Columns:Status"]">
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetStatusColor(context)">
+                        @GetStatusText(context)
+                    </MudChip>
+                </MudTd>
+                <MudTd DataLabel="@L["Clusters:Columns:Actions"]">
+                    <MudStack Row="true" Spacing="1">
+                        <MudTooltip Text="@L["Common:Actions:Select"]">
+                            <MudIconButton Icon="@Icons.Material.Filled.CheckCircle"
+                                           Size="Size.Small"
+                                           Disabled="@State.IsBusy"
+                                           OnClick="@(() => OnSelect.InvokeAsync(context))" />
+                        </MudTooltip>
+                        <MudTooltip Text="@L["Common:Actions:Edit"]">
+                            <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                           Size="Size.Small"
+                                           Disabled="@State.IsBusy"
+                                           OnClick="@(() => OnEdit.InvokeAsync(context))" />
+                        </MudTooltip>
+                        <MudTooltip Text="@L["Clusters:Actions:Test"]">
+                            <MudIconButton Icon="@Icons.Material.Filled.Cable"
+                                           Size="Size.Small"
+                                           Disabled="@(State.IsBusy || !context.Config.HasDirectKafkaAccess)"
+                                           OnClick="@(() => OnTest.InvokeAsync(context))" />
+                        </MudTooltip>
+                        <MudTooltip Text="@L["Common:Actions:Delete"]">
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                           Size="Size.Small"
+                                           Color="Color.Error"
+                                           Disabled="@State.IsBusy"
+                                           OnClick="@(() => OnDelete.InvokeAsync(context))" />
+                        </MudTooltip>
+                    </MudStack>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public EventBusKafkaPageState State { get; set; } = default!;
+
+    [Parameter] public EventCallback OnCreate { get; set; }
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    [Parameter] public EventCallback<KafkaClusterSummary> OnSelect { get; set; }
+
+    [Parameter] public EventCallback<KafkaClusterSummary> OnEdit { get; set; }
+
+    [Parameter] public EventCallback<KafkaClusterSummary> OnDelete { get; set; }
+
+    [Parameter] public EventCallback<KafkaClusterSummary> OnTest { get; set; }
+
+    private string GetBootstrapText(KafkaClusterSummary cluster)
+    {
+        return string.IsNullOrWhiteSpace(cluster.Config.BootstrapServers)
+            ? L["Clusters:Values:ExternalBootstrap"]
+            : cluster.Config.BootstrapServers;
+    }
+
+    private string GetClusterMode(KafkaClusterSummary cluster)
+    {
+        return cluster.Config.IsDaprBacked ? L["Clusters:Modes:DaprBacked"] : L["Clusters:Modes:Direct"];
+    }
+
+    private Color GetClusterModeColor(KafkaClusterSummary cluster)
+    {
+        return cluster.Config.IsDaprBacked ? Color.Info : Color.Primary;
+    }
+
+    private string GetStatusText(KafkaClusterSummary cluster)
+    {
+        if (cluster.IsReachable)
+        {
+            return L["Clusters:Status:Reachable"];
+        }
+
+        return cluster.Config.HasDirectKafkaAccess ? L["Clusters:Status:Unknown"] : L["Clusters:Status:Limited"];
+    }
+
+    private Color GetStatusColor(KafkaClusterSummary cluster)
+    {
+        if (cluster.IsReachable)
+        {
+            return Color.Success;
+        }
+
+        return cluster.Config.HasDirectKafkaAccess ? Color.Secondary : Color.Warning;
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaConsumerGroupsTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaConsumerGroupsTab.razor
@@ -1,0 +1,55 @@
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudStack Spacing="3">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+        <MudText Typo="Typo.h6">@L["ConsumerGroups:Title"]</MudText>
+        <MudButton Variant="Variant.Outlined"
+                   StartIcon="@Icons.Material.Filled.Refresh"
+                   Disabled="@State.IsBusy"
+                   OnClick="OnRefresh">
+            @L["Common:Actions:Refresh"]
+        </MudButton>
+    </MudStack>
+
+    @if (!State.CanAdminSelectedCluster)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+            @L["ConsumerGroups:Unavailable"]
+        </MudAlert>
+    }
+    else if (State.ConsumerGroups.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            @L["ConsumerGroups:Empty"]
+        </MudAlert>
+    }
+    else
+    {
+        <MudTable T="KafkaConsumerGroupSummary" Items="@State.ConsumerGroups" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>@L["ConsumerGroups:Columns:GroupId"]</MudTh>
+                <MudTh>@L["ConsumerGroups:Columns:State"]</MudTh>
+                <MudTh>@L["ConsumerGroups:Columns:Members"]</MudTh>
+                <MudTh>@L["ConsumerGroups:Columns:Lag"]</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="@L["ConsumerGroups:Columns:GroupId"]">@context.GroupId</MudTd>
+                <MudTd DataLabel="@L["ConsumerGroups:Columns:State"]">@context.State</MudTd>
+                <MudTd DataLabel="@L["ConsumerGroups:Columns:Members"]">@context.MemberCount</MudTd>
+                <MudTd DataLabel="@L["ConsumerGroups:Columns:Lag"]">@FormatLag(context.TotalLag)</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public EventBusKafkaPageState State { get; set; } = default!;
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    private string FormatLag(long? lag)
+    {
+        return lag?.ToString() ?? L["ConsumerGroups:Values:LagUnknown"];
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaDashboardTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaDashboardTab.razor
@@ -3,7 +3,7 @@
 
 <MudStack Spacing="3">
     <MudGrid Spacing="3">
-        <MudItem xs="12" md="6" lg="3">
+        <MudItem xs="12" md="6" lg="2">
             <MudPaper Class="pa-4" Outlined="true">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.overline">@L["Dashboard:Cards:Provider"]</MudText>
@@ -14,7 +14,7 @@
                 </MudStack>
             </MudPaper>
         </MudItem>
-        <MudItem xs="12" md="6" lg="3">
+        <MudItem xs="12" md="6" lg="2">
             <MudPaper Class="pa-4" Outlined="true">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.overline">@L["Dashboard:Cards:Brokers"]</MudText>
@@ -23,7 +23,7 @@
                 </MudStack>
             </MudPaper>
         </MudItem>
-        <MudItem xs="12" md="6" lg="3">
+        <MudItem xs="12" md="6" lg="2">
             <MudPaper Class="pa-4" Outlined="true">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.overline">@L["Dashboard:Cards:Topics"]</MudText>
@@ -32,12 +32,30 @@
                 </MudStack>
             </MudPaper>
         </MudItem>
-        <MudItem xs="12" md="6" lg="3">
+        <MudItem xs="12" md="6" lg="2">
             <MudPaper Class="pa-4" Outlined="true">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.overline">@L["Dashboard:Cards:ConsumerGroups"]</MudText>
                     <MudText Typo="Typo.h5">@State.Dashboard.ConsumerGroupCount</MudText>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:ConsumerGroupsHint"]</MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="2">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:WriteRate"]</MudText>
+                    <MudText Typo="Typo.h5">@FormatRate(State.Dashboard.LatestPerformance?.MessageWriteRatePerSecond)</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:WriteRateHint"]</MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="2">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:ConsumeRate"]</MudText>
+                    <MudText Typo="Typo.h5">@FormatRate(State.Dashboard.LatestPerformance?.MessageConsumeRatePerSecond)</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:ConsumeRateHint"]</MudText>
                 </MudStack>
             </MudPaper>
         </MudItem>
@@ -102,4 +120,11 @@
             : State.SelectedCluster.Config.HasDirectKafkaAccess
                 ? State.SelectedCluster.Config.BootstrapServers
                 : L["Dashboard:SelectedCluster:ExternalCredentials"];
+
+    private string FormatRate(double? rate)
+    {
+        return rate.HasValue
+            ? L["Performance:Values:RatePerSecond", rate.Value.ToString("0.##")]
+            : L["Performance:Values:RateUnknown"];
+    }
 }

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaDashboardTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaDashboardTab.razor
@@ -1,0 +1,105 @@
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudStack Spacing="3">
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="6" lg="3">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:Provider"]</MudText>
+                    <MudText Typo="Typo.h6">@State.Integration.ActiveProviderName</MudText>
+                    <MudChip T="string" Size="Size.Small" Color="@ModeColor" Variant="Variant.Outlined">
+                        @ModeLabel
+                    </MudChip>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="3">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:Brokers"]</MudText>
+                    <MudText Typo="Typo.h5">@State.Dashboard.BrokerCount</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:BrokersHint"]</MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="3">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:Topics"]</MudText>
+                    <MudText Typo="Typo.h5">@State.Dashboard.TopicCount</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:TopicsHint"]</MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="3">
+            <MudPaper Class="pa-4" Outlined="true">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline">@L["Dashboard:Cards:ConsumerGroups"]</MudText>
+                    <MudText Typo="Typo.h5">@State.Dashboard.ConsumerGroupCount</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Dashboard:Cards:ConsumerGroupsHint"]</MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    @if (State.Integration.Messages.Count > 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            <MudStack Spacing="1">
+                @foreach (var message in State.Integration.Messages)
+                {
+                    <MudText Typo="Typo.body2">@message</MudText>
+                }
+            </MudStack>
+        </MudAlert>
+    }
+
+    <MudPaper Class="pa-4" Outlined="true">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Start" Spacing="2">
+            <MudStack Spacing="1">
+                <MudText Typo="Typo.h6">@SelectedClusterName</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">@SelectedClusterSubtitle</MudText>
+            </MudStack>
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       Disabled="@State.IsBusy"
+                       OnClick="OnRefresh">
+                @L["Common:Actions:Refresh"]
+            </MudButton>
+        </MudStack>
+    </MudPaper>
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public EventBusKafkaPageState State { get; set; } = default!;
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    private string ModeLabel => State.Integration.Mode switch
+    {
+        KafkaIntegrationMode.DirectKafka => L["Dashboard:Modes:DirectKafka"],
+        KafkaIntegrationMode.DaprKafka => L["Dashboard:Modes:DaprKafka"],
+        KafkaIntegrationMode.DaprNonKafka => L["Dashboard:Modes:DaprNonKafka"],
+        KafkaIntegrationMode.NotConfigured => L["Dashboard:Modes:NotConfigured"],
+        _ => L["Dashboard:Modes:Unknown"]
+    };
+
+    private Color ModeColor => State.Integration.Mode switch
+    {
+        KafkaIntegrationMode.DirectKafka or KafkaIntegrationMode.DaprKafka => Color.Success,
+        KafkaIntegrationMode.DaprNonKafka => Color.Warning,
+        KafkaIntegrationMode.NotConfigured => Color.Secondary,
+        _ => Color.Default
+    };
+
+    private string SelectedClusterName =>
+        State.SelectedCluster?.Config.DisplayName ?? L["Dashboard:SelectedCluster:None"];
+
+    private string SelectedClusterSubtitle =>
+        State.SelectedCluster is null
+            ? L["Dashboard:SelectedCluster:NoneDescription"]
+            : State.SelectedCluster.Config.HasDirectKafkaAccess
+                ? State.SelectedCluster.Config.BootstrapServers
+                : L["Dashboard:SelectedCluster:ExternalCredentials"];
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaPerformanceTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaPerformanceTab.razor
@@ -1,0 +1,75 @@
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudStack Spacing="3">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+        <MudText Typo="Typo.h6">@L["Performance:Title"]</MudText>
+        <MudStack Row="true" Spacing="1">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       Disabled="@State.IsBusy"
+                       OnClick="OnRefresh">
+                @L["Common:Actions:Refresh"]
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.MonitorHeart"
+                       Disabled="@(State.IsBusy || !State.CanAdminSelectedCluster)"
+                       OnClick="OnCapture">
+                @L["Performance:Actions:Capture"]
+            </MudButton>
+        </MudStack>
+    </MudStack>
+
+    @if (!State.CanAdminSelectedCluster)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+            @L["Performance:Unavailable"]
+        </MudAlert>
+    }
+    else if (State.PerformanceSnapshots.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            @L["Performance:Empty"]
+        </MudAlert>
+    }
+    else
+    {
+        <MudTable T="KafkaPerformanceSnapshot" Items="@State.PerformanceSnapshots.OrderByDescending(snapshot => snapshot.CapturedAt)" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>@L["Performance:Columns:CapturedAt"]</MudTh>
+                <MudTh>@L["Performance:Columns:Brokers"]</MudTh>
+                <MudTh>@L["Performance:Columns:Topics"]</MudTh>
+                <MudTh>@L["Performance:Columns:Groups"]</MudTh>
+                <MudTh>@L["Performance:Columns:Lag"]</MudTh>
+                <MudTh>@L["Performance:Columns:Message"]</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="@L["Performance:Columns:CapturedAt"]">@context.CapturedAt.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:Brokers"]">@context.BrokerCount</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:Topics"]">@context.TopicCount</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:Groups"]">@context.ConsumerGroupCount</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:Lag"]">@FormatLag(context.TotalLag)</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:Message"]">@FormatMessage(context.Message)</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public EventBusKafkaPageState State { get; set; } = default!;
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    [Parameter] public EventCallback OnCapture { get; set; }
+
+    private string FormatLag(long? lag)
+    {
+        return lag?.ToString() ?? L["Performance:Values:LagUnknown"];
+    }
+
+    private string FormatMessage(string? message)
+    {
+        return string.IsNullOrWhiteSpace(message) ? L["Performance:Values:NoMessage"] : message;
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaPerformanceTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaPerformanceTab.razor
@@ -41,6 +41,8 @@
                 <MudTh>@L["Performance:Columns:Brokers"]</MudTh>
                 <MudTh>@L["Performance:Columns:Topics"]</MudTh>
                 <MudTh>@L["Performance:Columns:Groups"]</MudTh>
+                <MudTh>@L["Performance:Columns:WriteRate"]</MudTh>
+                <MudTh>@L["Performance:Columns:ConsumeRate"]</MudTh>
                 <MudTh>@L["Performance:Columns:Lag"]</MudTh>
                 <MudTh>@L["Performance:Columns:Message"]</MudTh>
             </HeaderContent>
@@ -49,6 +51,8 @@
                 <MudTd DataLabel="@L["Performance:Columns:Brokers"]">@context.BrokerCount</MudTd>
                 <MudTd DataLabel="@L["Performance:Columns:Topics"]">@context.TopicCount</MudTd>
                 <MudTd DataLabel="@L["Performance:Columns:Groups"]">@context.ConsumerGroupCount</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:WriteRate"]">@FormatRate(context.MessageWriteRatePerSecond)</MudTd>
+                <MudTd DataLabel="@L["Performance:Columns:ConsumeRate"]">@FormatRate(context.MessageConsumeRatePerSecond)</MudTd>
                 <MudTd DataLabel="@L["Performance:Columns:Lag"]">@FormatLag(context.TotalLag)</MudTd>
                 <MudTd DataLabel="@L["Performance:Columns:Message"]">@FormatMessage(context.Message)</MudTd>
             </RowTemplate>
@@ -66,6 +70,13 @@
     private string FormatLag(long? lag)
     {
         return lag?.ToString() ?? L["Performance:Values:LagUnknown"];
+    }
+
+    private string FormatRate(double? rate)
+    {
+        return rate.HasValue
+            ? L["Performance:Values:RatePerSecond", rate.Value.ToString("0.##")]
+            : L["Performance:Values:RateUnknown"];
     }
 
     private string FormatMessage(string? message)

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaTopicsTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaTopicsTab.razor
@@ -61,6 +61,9 @@
                              Size="Size.Small"
                              Dense="true"
                              Disabled="@State.IsBusy">
+                        <MudMenuItem Icon="@Icons.Material.Filled.Visibility" OnClick="@(() => OnViewMessages.InvokeAsync(context))">
+                            @L["Topics:Actions:Messages"]
+                        </MudMenuItem>
                         <MudMenuItem Icon="@Icons.Material.Filled.CallSplit" OnClick="@(() => OnIncreasePartitions.InvokeAsync(context))">
                             @L["Topics:Actions:Partitions"]
                         </MudMenuItem>
@@ -85,6 +88,8 @@
     [Parameter] public EventCallback OnRefresh { get; set; }
 
     [Parameter] public EventCallback<KafkaTopicSummary> OnDelete { get; set; }
+
+    [Parameter] public EventCallback<KafkaTopicSummary> OnViewMessages { get; set; }
 
     [Parameter] public EventCallback<KafkaTopicSummary> OnIncreasePartitions { get; set; }
 

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaTopicsTab.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Components/KafkaTopicsTab.razor
@@ -1,0 +1,99 @@
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudStack Spacing="3">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+        <MudText Typo="Typo.h6">@L["Topics:Title"]</MudText>
+        <MudStack Row="true" Spacing="1">
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       Disabled="@State.IsBusy"
+                       OnClick="OnRefresh">
+                @L["Common:Actions:Refresh"]
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       Disabled="@(State.IsBusy || !State.CanAdminSelectedCluster)"
+                       OnClick="OnCreate">
+                @L["Topics:Actions:Create"]
+            </MudButton>
+        </MudStack>
+    </MudStack>
+
+    @if (!State.CanAdminSelectedCluster)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+            @L["Topics:Unavailable"]
+        </MudAlert>
+    }
+    else if (State.Topics.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            @L["Topics:Empty"]
+        </MudAlert>
+    }
+    else
+    {
+        <MudTable T="KafkaTopicSummary" Items="@State.Topics" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>@L["Topics:Columns:Name"]</MudTh>
+                <MudTh>@L["Topics:Columns:Partitions"]</MudTh>
+                <MudTh>@L["Topics:Columns:Replication"]</MudTh>
+                <MudTh>@L["Topics:Columns:Retention"]</MudTh>
+                <MudTh>@L["Topics:Columns:Actions"]</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="@L["Topics:Columns:Name"]">
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.body2">@context.TopicName</MudText>
+                        @if (context.IsInternal)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Topics:Values:Internal"]</MudText>
+                        }
+                    </MudStack>
+                </MudTd>
+                <MudTd DataLabel="@L["Topics:Columns:Partitions"]">@context.Partitions</MudTd>
+                <MudTd DataLabel="@L["Topics:Columns:Replication"]">@context.ReplicationFactor</MudTd>
+                <MudTd DataLabel="@L["Topics:Columns:Retention"]">@FormatRetention(context.RetentionMs)</MudTd>
+                <MudTd DataLabel="@L["Topics:Columns:Actions"]">
+                    <MudMenu Icon="@Icons.Material.Filled.MoreVert"
+                             Size="Size.Small"
+                             Dense="true"
+                             Disabled="@State.IsBusy">
+                        <MudMenuItem Icon="@Icons.Material.Filled.CallSplit" OnClick="@(() => OnIncreasePartitions.InvokeAsync(context))">
+                            @L["Topics:Actions:Partitions"]
+                        </MudMenuItem>
+                        <MudMenuItem Icon="@Icons.Material.Filled.Schedule" OnClick="@(() => OnUpdateRetention.InvokeAsync(context))">
+                            @L["Topics:Actions:Retention"]
+                        </MudMenuItem>
+                        <MudMenuItem Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDelete.InvokeAsync(context))">
+                            @L["Common:Actions:Delete"]
+                        </MudMenuItem>
+                    </MudMenu>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public EventBusKafkaPageState State { get; set; } = default!;
+
+    [Parameter] public EventCallback OnCreate { get; set; }
+
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    [Parameter] public EventCallback<KafkaTopicSummary> OnDelete { get; set; }
+
+    [Parameter] public EventCallback<KafkaTopicSummary> OnIncreasePartitions { get; set; }
+
+    [Parameter] public EventCallback<KafkaTopicSummary> OnUpdateRetention { get; set; }
+
+    private string FormatRetention(long? retentionMs)
+    {
+        return retentionMs is null
+            ? L["Topics:Values:RetentionUnknown"]
+            : L["Topics:Values:RetentionMs", retentionMs.Value];
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/CreateKafkaClusterDialog.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/CreateKafkaClusterDialog.razor
@@ -1,0 +1,111 @@
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @if (!string.IsNullOrWhiteSpace(_errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    @_errorMessage
+                </MudAlert>
+            }
+
+            <MudGrid Spacing="3">
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.DisplayName" Label="@L["Clusters:Fields:DisplayName"]" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.ClusterId" Label="@L["Clusters:Fields:ClusterId"]" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField T="string" @bind-Value="_model.BootstrapServers" Label="@L["Clusters:Fields:BootstrapServers"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.ClientId" Label="@L["Clusters:Fields:ClientId"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.JmxEndpoint" Label="@L["Clusters:Fields:JmxEndpoint"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.SecurityProtocol" Label="@L["Clusters:Fields:SecurityProtocol"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.SaslMechanism" Label="@L["Clusters:Fields:SaslMechanism"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_model.SaslUsername" Label="@L["Clusters:Fields:SaslUsername"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string"
+                                  @bind-Value="_model.SaslPassword"
+                                  Label="@L["Clusters:Fields:SaslPassword"]"
+                                  InputType="InputType.Password" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField T="string" @bind-Value="_model.SslCaLocation" Label="@L["Clusters:Fields:SslCaLocation"]" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudSwitch T="bool" @bind-Value="_model.IsDaprBacked" Color="Color.Primary">
+                        @L["Clusters:Fields:IsDaprBacked"]
+                    </MudSwitch>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudSwitch T="bool" @bind-Value="_model.CredentialsManagedExternally" Color="Color.Primary">
+                        @L["Clusters:Fields:CredentialsManagedExternally"]
+                    </MudSwitch>
+                </MudItem>
+                @if (_model.IsDaprBacked)
+                {
+                    <MudItem xs="12">
+                        <MudTextField T="string" @bind-Value="_model.DaprPubSubName" Label="@L["Clusters:Fields:DaprPubSubName"]" />
+                    </MudItem>
+                }
+            </MudGrid>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" OnClick="Cancel">@L["Common:Actions:Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save">@L["Common:Actions:Save"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter] public KafkaClusterConfig? Cluster { get; set; }
+
+    private KafkaClusterConfig _model = new();
+
+    private string? _errorMessage;
+
+    protected override void OnInitialized()
+    {
+        _model = Cluster?.Clone() ?? new KafkaClusterConfig
+        {
+            CredentialsManagedExternally = false
+        };
+    }
+
+    private void Save()
+    {
+        _errorMessage = null;
+        if (string.IsNullOrWhiteSpace(_model.DisplayName))
+        {
+            _errorMessage = L["Clusters:Validation:DisplayNameRequired"];
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_model.BootstrapServers) && !_model.CredentialsManagedExternally)
+        {
+            _errorMessage = L["Clusters:Validation:BootstrapRequired"];
+            return;
+        }
+
+        MudDialog?.Close(DialogResult.Ok(_model.Clone().Normalize()));
+    }
+
+    private void Cancel()
+    {
+        MudDialog?.Cancel();
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/CreateKafkaTopicDialog.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/CreateKafkaTopicDialog.razor
@@ -1,0 +1,65 @@
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @if (!string.IsNullOrWhiteSpace(_errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    @_errorMessage
+                </MudAlert>
+            }
+
+            <MudTextField T="string" @bind-Value="_topicName" Label="@L["Topics:Fields:TopicName"]" Required="true" />
+            <MudNumericField T="int" @bind-Value="_partitions" Label="@L["Topics:Fields:Partitions"]" Min="1" />
+            <MudNumericField T="int" @bind-Value="_replicationFactor" Label="@L["Topics:Fields:ReplicationFactor"]" Min="1" />
+            <MudNumericField T="long?" @bind-Value="_retentionMs" Label="@L["Topics:Fields:RetentionMs"]" Min="1" />
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" OnClick="Cancel">@L["Common:Actions:Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save">@L["Topics:Actions:Create"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter, EditorRequired] public string ClusterId { get; set; } = string.Empty;
+
+    private string _topicName = string.Empty;
+
+    private int _partitions = 1;
+
+    private int _replicationFactor = 1;
+
+    private long? _retentionMs;
+
+    private string? _errorMessage;
+
+    private void Save()
+    {
+        _errorMessage = null;
+        if (string.IsNullOrWhiteSpace(_topicName))
+        {
+            _errorMessage = L["Topics:Validation:NameRequired"];
+            return;
+        }
+
+        var request = new KafkaTopicCreateRequest
+        {
+            ClusterId = ClusterId,
+            TopicName = _topicName.Trim(),
+            Partitions = Math.Max(1, _partitions),
+            ReplicationFactor = (short)Math.Max(1, _replicationFactor),
+            RetentionMs = _retentionMs
+        };
+
+        MudDialog?.Close(DialogResult.Ok(request));
+    }
+
+    private void Cancel()
+    {
+        MudDialog?.Cancel();
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaMessagesDialog.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaMessagesDialog.razor
@@ -1,0 +1,114 @@
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudDialog>
+    <DialogContent>
+        <div class="message-dialog">
+            <MudStack Spacing="3">
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                    @L["Topics:MessagesDialog:ReadHint", Batch.MaxMessages, FormatCapturedAt()]
+                </MudAlert>
+
+                @if (Batch.Messages.Count == 0)
+                {
+                    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                        @L["Topics:MessagesDialog:Empty"]
+                    </MudAlert>
+                }
+                else
+                {
+                    @foreach (var message in Batch.Messages)
+                    {
+                        <section class="message-item">
+                            <div class="message-item__header">
+                                <MudText Typo="Typo.subtitle2">
+                                    @L["Topics:MessagesDialog:OffsetFormat", message.Partition, message.Offset]
+                                </MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @FormatTimestamp(message)
+                                </MudText>
+                            </div>
+
+                            <dl class="message-meta">
+                                <div>
+                                    <dt>@L["Topics:MessagesDialog:Key"]</dt>
+                                    <dd>@FormatKey(message)</dd>
+                                </div>
+                                <div>
+                                    <dt>@L["Topics:MessagesDialog:Encoding"]</dt>
+                                    <dd>@FormatEncoding(message)</dd>
+                                </div>
+                                <div>
+                                    <dt>@L["Topics:MessagesDialog:Size"]</dt>
+                                    <dd>@L["Topics:MessagesDialog:SizeBytes", message.ValueSizeBytes]</dd>
+                                </div>
+                            </dl>
+
+                            @if (message.IsTruncated)
+                            {
+                                <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Dense="true">
+                                    @L["Topics:MessagesDialog:Truncated"]
+                                </MudAlert>
+                            }
+
+                            <pre class="message-body">@FormatValue(message)</pre>
+                        </section>
+                    }
+                }
+            </MudStack>
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Close">
+            @L["Common:Actions:Close"]
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter, EditorRequired] public KafkaTopicMessageBatch Batch { get; set; } = new();
+
+    private string FormatCapturedAt()
+    {
+        return Batch.CapturedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+    }
+
+    private string FormatTimestamp(KafkaTopicMessageSample message)
+    {
+        return message.Timestamp is null
+            ? L["Topics:Values:TimestampUnknown"]
+            : message.Timestamp.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff zzz");
+    }
+
+    private string FormatKey(KafkaTopicMessageSample message)
+    {
+        return string.IsNullOrEmpty(message.Key)
+            ? L["Topics:Values:NoKey"]
+            : message.Key;
+    }
+
+    private string FormatEncoding(KafkaTopicMessageSample message)
+    {
+        return message.IsTombstone
+            ? L["Topics:Values:TombstoneEncoding"]
+            : message.ValueEncoding;
+    }
+
+    private string FormatValue(KafkaTopicMessageSample message)
+    {
+        if (message.IsTombstone)
+        {
+            return L["Topics:Values:Tombstone"];
+        }
+
+        return string.IsNullOrEmpty(message.Value)
+            ? L["Topics:Values:EmptyValue"]
+            : message.Value;
+    }
+
+    private void Close()
+    {
+        MudDialog?.Close();
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaMessagesDialog.razor.css
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaMessagesDialog.razor.css
@@ -1,0 +1,71 @@
+.message-dialog {
+    max-height: min(72vh, 760px);
+    overflow: auto;
+    padding-right: 4px;
+}
+
+.message-item {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 8px;
+    background: var(--mud-palette-surface);
+}
+
+.message-item__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.message-meta {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin: 0;
+}
+
+.message-meta div {
+    min-width: 0;
+}
+
+.message-meta dt {
+    margin: 0 0 3px;
+    color: var(--mud-palette-text-secondary);
+    font-size: 0.75rem;
+}
+
+.message-meta dd {
+    margin: 0;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.message-body {
+    max-height: 260px;
+    margin: 0;
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid var(--mud-palette-lines-default);
+    background: var(--mud-palette-background-gray);
+    color: var(--mud-palette-text-primary);
+    font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.55;
+}
+
+@media (max-width: 720px) {
+    .message-item__header {
+        flex-direction: column;
+    }
+
+    .message-meta {
+        grid-template-columns: 1fr;
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaPartitionDialog.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaPartitionDialog.razor
@@ -1,0 +1,57 @@
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @if (!string.IsNullOrWhiteSpace(_errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    @_errorMessage
+                </MudAlert>
+            }
+
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                @L["Topics:Dialog:PartitionsMessage", Topic.TopicName, Topic.Partitions]
+            </MudText>
+            <MudNumericField T="int" @bind-Value="_increaseTo" Label="@L["Topics:Fields:IncreaseTo"]" Min="@MinimumValue" />
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" OnClick="Cancel">@L["Common:Actions:Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save">@L["Common:Actions:Save"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter, EditorRequired] public KafkaTopicSummary Topic { get; set; } = new();
+
+    private int _increaseTo;
+
+    private string? _errorMessage;
+
+    private int MinimumValue => Math.Max(Topic.Partitions + 1, 1);
+
+    protected override void OnInitialized()
+    {
+        _increaseTo = MinimumValue;
+    }
+
+    private void Save()
+    {
+        _errorMessage = null;
+        if (_increaseTo <= Topic.Partitions)
+        {
+            _errorMessage = L["Topics:Validation:PartitionIncreaseRequired"];
+            return;
+        }
+
+        MudDialog?.Close(DialogResult.Ok(_increaseTo));
+    }
+
+    private void Cancel()
+    {
+        MudDialog?.Cancel();
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaRetentionDialog.razor
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/Dialogs/KafkaRetentionDialog.razor
@@ -1,0 +1,55 @@
+@inject IStringLocalizer<EventBusKafkaResource> L
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @if (!string.IsNullOrWhiteSpace(_errorMessage))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    @_errorMessage
+                </MudAlert>
+            }
+
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                @L["Topics:Dialog:RetentionMessage", Topic.TopicName]
+            </MudText>
+            <MudNumericField T="long" @bind-Value="_retentionMs" Label="@L["Topics:Fields:RetentionMs"]" Min="1" />
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" OnClick="Cancel">@L["Common:Actions:Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save">@L["Common:Actions:Save"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter, EditorRequired] public KafkaTopicSummary Topic { get; set; } = new();
+
+    private long _retentionMs;
+
+    private string? _errorMessage;
+
+    protected override void OnInitialized()
+    {
+        _retentionMs = Topic.RetentionMs.GetValueOrDefault(604800000);
+    }
+
+    private void Save()
+    {
+        _errorMessage = null;
+        if (_retentionMs <= 0)
+        {
+            _errorMessage = L["Topics:Validation:RetentionRequired"];
+            return;
+        }
+
+        MudDialog?.Close(DialogResult.Ok(_retentionMs));
+    }
+
+    private void Cancel()
+    {
+        MudDialog?.Cancel();
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
@@ -1,0 +1,439 @@
+using Monica.Core.Results;
+using Monica.EventBus.Kafka.Facades;
+using Monica.EventBus.Kafka.Models;
+
+namespace Monica.EventBus.Kafka.UIEventBusKafka.State;
+
+/// <summary>
+/// Page state for the Kafka EventBus console.
+/// </summary>
+public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
+{
+    /// <summary>
+    /// Current integration snapshot.
+    /// </summary>
+    public KafkaIntegrationSnapshot Integration { get; private set; } = new();
+
+    /// <summary>
+    /// Visible Kafka clusters.
+    /// </summary>
+    public List<KafkaClusterSummary> Clusters { get; private set; } = [];
+
+    /// <summary>
+    /// Selected cluster dashboard.
+    /// </summary>
+    public KafkaDashboardSnapshot Dashboard { get; private set; } = new();
+
+    /// <summary>
+    /// Topics for the selected cluster.
+    /// </summary>
+    public List<KafkaTopicSummary> Topics { get; private set; } = [];
+
+    /// <summary>
+    /// Consumer groups for the selected cluster.
+    /// </summary>
+    public List<KafkaConsumerGroupSummary> ConsumerGroups { get; private set; } = [];
+
+    /// <summary>
+    /// Performance snapshots for the selected cluster.
+    /// </summary>
+    public List<KafkaPerformanceSnapshot> PerformanceSnapshots { get; private set; } = [];
+
+    /// <summary>
+    /// Selected cluster id.
+    /// </summary>
+    public string? SelectedClusterId { get; private set; }
+
+    /// <summary>
+    /// Last operation error message.
+    /// </summary>
+    public string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// Whether the page is loading initial data.
+    /// </summary>
+    public bool IsLoading { get; private set; }
+
+    /// <summary>
+    /// Whether an operation is in progress.
+    /// </summary>
+    public bool IsBusy { get; private set; }
+
+    /// <summary>
+    /// Selected cluster summary.
+    /// </summary>
+    public KafkaClusterSummary? SelectedCluster =>
+        Clusters.FirstOrDefault(cluster => string.Equals(cluster.Config.ClusterId, SelectedClusterId, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Whether the selected cluster supports direct Kafka admin operations.
+    /// </summary>
+    public bool CanAdminSelectedCluster => SelectedCluster?.Config.HasDirectKafkaAccess == true;
+
+    /// <summary>
+    /// Initializes all page data.
+    /// </summary>
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        IsLoading = true;
+        try
+        {
+            await RefreshAsync(cancellationToken);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// Refreshes integration, cluster, dashboard, and selected cluster details.
+    /// </summary>
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.GetIntegrationAsync(cancellationToken), out var integration))
+            {
+                return;
+            }
+
+            Integration = integration;
+
+            if (!TryRead(await facade.ListClustersAsync(cancellationToken), out var clusters))
+            {
+                return;
+            }
+
+            Clusters = clusters.ToList();
+            SelectedClusterId = ResolveSelectedClusterId();
+
+            if (!TryRead(await facade.GetDashboardAsync(SelectedClusterId, cancellationToken), out var dashboard))
+            {
+                return;
+            }
+
+            Dashboard = dashboard;
+            await RefreshSelectedClusterDetailsAsync(cancellationToken);
+        });
+    }
+
+    /// <summary>
+    /// Selects a cluster and loads detail tabs.
+    /// </summary>
+    public async Task SelectClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        SelectedClusterId = clusterId;
+        await RunAsync(async () =>
+        {
+            if (TryRead(await facade.GetDashboardAsync(clusterId, cancellationToken), out var dashboard))
+            {
+                Dashboard = dashboard;
+            }
+
+            await RefreshSelectedClusterDetailsAsync(cancellationToken);
+        });
+    }
+
+    /// <summary>
+    /// Creates or updates a cluster.
+    /// </summary>
+    public async Task<bool> UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    {
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.UpsertClusterAsync(new KafkaClusterUpsertRequest { Cluster = cluster }, cancellationToken), out var summary))
+            {
+                return false;
+            }
+
+            SelectedClusterId = summary.Config.ClusterId;
+            await RefreshAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Deletes a cluster.
+    /// </summary>
+    public async Task<bool> DeleteClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.DeleteClusterAsync(clusterId, cancellationToken)))
+            {
+                return false;
+            }
+
+            if (string.Equals(SelectedClusterId, clusterId, StringComparison.Ordinal))
+            {
+                SelectedClusterId = null;
+            }
+
+            await RefreshAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Tests the selected cluster.
+    /// </summary>
+    public async Task<bool> TestClusterAsync(string clusterId, CancellationToken cancellationToken = default)
+    {
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.TestClusterAsync(clusterId, cancellationToken), out _))
+            {
+                return false;
+            }
+
+            await RefreshAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Creates a topic in the selected cluster.
+    /// </summary>
+    public async Task<bool> CreateTopicAsync(KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.CreateTopicAsync(request, cancellationToken)))
+            {
+                return false;
+            }
+
+            await RefreshTopicsAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Deletes a topic from the selected cluster.
+    /// </summary>
+    public async Task<bool> DeleteTopicAsync(string topicName, CancellationToken cancellationToken = default)
+    {
+        if (SelectedClusterId is null)
+        {
+            return false;
+        }
+
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.DeleteTopicAsync(SelectedClusterId, topicName, cancellationToken)))
+            {
+                return false;
+            }
+
+            await RefreshTopicsAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Increases a topic partition count.
+    /// </summary>
+    public async Task<bool> IncreasePartitionsAsync(string topicName, int increaseTo, CancellationToken cancellationToken = default)
+    {
+        if (SelectedClusterId is null)
+        {
+            return false;
+        }
+
+        return await RunAsync(async () =>
+        {
+            var request = new KafkaTopicPartitionRequest
+            {
+                ClusterId = SelectedClusterId,
+                TopicName = topicName,
+                IncreaseTo = increaseTo
+            };
+
+            if (!TryRead(await facade.IncreasePartitionsAsync(request, cancellationToken)))
+            {
+                return false;
+            }
+
+            await RefreshTopicsAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Updates topic retention.
+    /// </summary>
+    public async Task<bool> UpdateRetentionAsync(string topicName, long retentionMs, CancellationToken cancellationToken = default)
+    {
+        if (SelectedClusterId is null)
+        {
+            return false;
+        }
+
+        return await RunAsync(async () =>
+        {
+            var request = new KafkaTopicRetentionRequest
+            {
+                ClusterId = SelectedClusterId,
+                TopicName = topicName,
+                RetentionMs = retentionMs
+            };
+
+            if (!TryRead(await facade.UpdateRetentionAsync(request, cancellationToken)))
+            {
+                return false;
+            }
+
+            await RefreshTopicsAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    /// <summary>
+    /// Captures and stores a fresh performance snapshot.
+    /// </summary>
+    public async Task<bool> CapturePerformanceAsync(CancellationToken cancellationToken = default)
+    {
+        if (SelectedClusterId is null)
+        {
+            return false;
+        }
+
+        return await RunAsync(async () =>
+        {
+            if (!TryRead(await facade.CapturePerformanceAsync(SelectedClusterId, cancellationToken), out _))
+            {
+                return false;
+            }
+
+            await RefreshPerformanceAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    private async Task RefreshSelectedClusterDetailsAsync(CancellationToken cancellationToken)
+    {
+        if (SelectedClusterId is null || !CanAdminSelectedCluster)
+        {
+            Topics = [];
+            ConsumerGroups = [];
+            PerformanceSnapshots = [];
+            return;
+        }
+
+        await RefreshTopicsAsync(cancellationToken);
+        await RefreshConsumerGroupsAsync(cancellationToken);
+        await RefreshPerformanceAsync(cancellationToken);
+    }
+
+    private async Task RefreshTopicsAsync(CancellationToken cancellationToken)
+    {
+        if (SelectedClusterId is null)
+        {
+            Topics = [];
+            return;
+        }
+
+        if (TryRead(await facade.ListTopicsAsync(SelectedClusterId, cancellationToken), out var topics))
+        {
+            Topics = topics.ToList();
+        }
+    }
+
+    private async Task RefreshConsumerGroupsAsync(CancellationToken cancellationToken)
+    {
+        if (SelectedClusterId is null)
+        {
+            ConsumerGroups = [];
+            return;
+        }
+
+        if (TryRead(await facade.ListConsumerGroupsAsync(SelectedClusterId, cancellationToken), out var groups))
+        {
+            ConsumerGroups = groups.ToList();
+        }
+    }
+
+    private async Task RefreshPerformanceAsync(CancellationToken cancellationToken)
+    {
+        if (SelectedClusterId is null)
+        {
+            PerformanceSnapshots = [];
+            return;
+        }
+
+        if (TryRead(await facade.GetPerformanceHistoryAsync(SelectedClusterId, cancellationToken: cancellationToken), out var snapshots))
+        {
+            PerformanceSnapshots = snapshots.ToList();
+        }
+    }
+
+    private string? ResolveSelectedClusterId()
+    {
+        if (!string.IsNullOrWhiteSpace(SelectedClusterId) &&
+            Clusters.Any(cluster => string.Equals(cluster.Config.ClusterId, SelectedClusterId, StringComparison.Ordinal)))
+        {
+            return SelectedClusterId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Integration.PrimaryClusterId) &&
+            Clusters.Any(cluster => string.Equals(cluster.Config.ClusterId, Integration.PrimaryClusterId, StringComparison.Ordinal)))
+        {
+            return Integration.PrimaryClusterId;
+        }
+
+        return Clusters.FirstOrDefault()?.Config.ClusterId;
+    }
+
+    private async Task RunAsync(Func<Task> action)
+    {
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task<bool> RunAsync(Func<Task<bool>> action)
+    {
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            return await action();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool TryRead(Res result)
+    {
+        if (!result.IsFailed(out var error))
+        {
+            return true;
+        }
+
+        ErrorMessage = error.Message;
+        return false;
+    }
+
+    private bool TryRead<T>(Res<T> result, out T data)
+    {
+        if (!result.IsFailed(out var error))
+        {
+            data = result.Data!;
+            return true;
+        }
+
+        data = default!;
+        ErrorMessage = error.Message;
+        return false;
+    }
+}

--- a/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
@@ -290,6 +290,38 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
     }
 
     /// <summary>
+    /// Reads a bounded sample of recent messages from a selected cluster topic.
+    /// </summary>
+    public async Task<KafkaTopicMessageBatch?> ReadTopicMessagesAsync(
+        string topicName,
+        int maxMessages,
+        CancellationToken cancellationToken = default)
+    {
+        if (SelectedClusterId is null)
+        {
+            return null;
+        }
+
+        KafkaTopicMessageBatch? batch = null;
+        await RunAsync(async () =>
+        {
+            var request = new KafkaTopicMessagesRequest
+            {
+                ClusterId = SelectedClusterId,
+                TopicName = topicName,
+                MaxMessages = maxMessages
+            };
+
+            if (TryRead(await facade.ReadTopicMessagesAsync(request, cancellationToken), out var loadedBatch))
+            {
+                batch = loadedBatch;
+            }
+        });
+
+        return batch;
+    }
+
+    /// <summary>
     /// Captures and stores a fresh performance snapshot.
     /// </summary>
     public async Task<bool> CapturePerformanceAsync(CancellationToken cancellationToken = default)

--- a/Monica.EventBus.Kafka/_Imports.razor
+++ b/Monica.EventBus.Kafka/_Imports.razor
@@ -1,0 +1,10 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.Extensions.Localization
+@using Monica.Core.Results
+@using Monica.EventBus.Kafka.Localization
+@using Monica.EventBus.Kafka.Models
+@using Monica.EventBus.Kafka.UIEventBusKafka.Components
+@using Monica.EventBus.Kafka.UIEventBusKafka.Dialogs
+@using Monica.EventBus.Kafka.UIEventBusKafka.State
+@using MudBlazor

--- a/Monica.EventBus/Abstractions/IEventBusProviderModule.cs
+++ b/Monica.EventBus/Abstractions/IEventBusProviderModule.cs
@@ -18,6 +18,11 @@ public enum EventBusProviderKind
     Dapr,
 
     /// <summary>
+    /// Apache Kafka event bus
+    /// </summary>
+    Kafka,
+
+    /// <summary>
     /// Unknown provider type
     /// </summary>
     Unknown

--- a/Monica.UI/Localization/UIRegistryResource/en-US.json
+++ b/Monica.UI/Localization/UIRegistryResource/en-US.json
@@ -89,6 +89,9 @@
     "EventBusMonitor": {
       "Title": "Event Bus Monitor"
     },
+    "EventBusKafka": {
+      "Title": "Kafka EventBus"
+    },
     "StateStoreManage": {
       "Title": "State Store Management"
     },

--- a/Monica.UI/Localization/UIRegistryResource/zh-CN.json
+++ b/Monica.UI/Localization/UIRegistryResource/zh-CN.json
@@ -89,6 +89,9 @@
     "EventBusMonitor": {
       "Title": "事件总线监控"
     },
+    "EventBusKafka": {
+      "Title": "Kafka EventBus"
+    },
     "StateStoreManage": {
       "Title": "状态存储管理"
     },

--- a/Monica.slnx
+++ b/Monica.slnx
@@ -32,6 +32,7 @@
   <Project Path="Monica.DependencyInjection/Monica.DependencyInjection.csproj" />
   <Project Path="Monica.Experimental/Monica.Experimental.csproj" />
   <Project Path="Monica.WebApi/Monica.WebApi.csproj" />
+  <Project Path="Monica.EventBus.Kafka/Monica.EventBus.Kafka.csproj" />
   <Project Path="Monica.EventBus/Monica.EventBus.csproj" />
   <Project Path="Monica.Framework.Generators/Monica.Framework.Generators.csproj" />
   <Project Path="Monica.Framework.UI/Monica.Framework.UI.csproj" />


### PR DESCRIPTION
 ## Summary

  新增 `Monica.EventBus.Kafka` 模块，提供 Kafka EventBus 集成与管理控制台能力。模块同时包含后端 API、Kafka 管理服务、性能采样逻辑和 Blazor UI，并保
  持与 Monica 现有 UI 风格一致。

  ## Changes

  - 新增 Kafka EventBus 控制台能力：
    - 仪表盘
    - 集群管理，支持新建、编辑、删除、测试集群
    - 主题管理，支持创建主题、删除主题、调整分区、更新保留时间
    - 性能监控与历史采样

    - 支持声明 Dapr Kafka 集群，不强制替换现有 EventBus Provider

  - 新增消息速率指标：
    - 采样 topic 最新 offset 与 consumer group committed offset
    - 基于连续性能快照计算消息写入速率和消费速率
    - 在仪表盘和性能监控表格中展示写入/消费 msg/s

  - 新增存储支持：
    - 默认内存仓储保存运行期集群配置和性能快照
    - 支持 EF Core 仓储持久化集群配置和性能快照

  - 保持现有架构隔离：
    - Kafka 控制台作为独立模块注册
    - 不影响现有 EventBus Provider 选择
    - 不改变默认 Dapr EventBus 行为

  ## Validation

  - `dotnet build 'D:\Documents\Code\MoLibrary\Monica.EventBus.Kafka\Monica.EventBus.Kafka.csproj' -m`
  - `dotnet build 'D:\Documents\Code\MoLibrary\Monica.slnx' -m --no-restore`
  - `python .agents\skills\monica-ui-localization\scripts\validate_localization.py --strict`
  - `python scripts\validate_ui_theme_tokens.py`

  以上验证均已通过，构建无 warning / error。

  ## Notes

  - 当前页面刷新不会保留选中的 Tab 和集群上下文，地址栏刷新后会回到默认集群选择逻辑；该问题已确认，但本 PR 暂不处理。
  - 默认内存仓储只在当前进程内保存性能快照，如需服务重启后保留数据，需要配置 EF Core store。
