### PR TITLE
fix: harden Kafka cluster connection testing

### DIFF
--- a/Monica.EventBus.Kafka/Abstractions/IKafkaAdminProvider.cs
+++ b/Monica.EventBus.Kafka/Abstractions/IKafkaAdminProvider.cs
@@ -16,7 +16,8 @@ public interface IKafkaAdminProvider
     /// </summary>
     /// <param name="cluster">Cluster configuration.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task TestConnectionAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
+    /// <returns>Connection metadata collected during the probe.</returns>
+    Task<KafkaConnectionTestResult> TestConnectionAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists brokers known by the target cluster metadata.

--- a/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
+++ b/Monica.EventBus.Kafka/Facades/KafkaConsoleFacade.cs
@@ -37,7 +37,11 @@ public sealed class KafkaConsoleFacade(
     /// </summary>
     public Task<Res<KafkaClusterSummary>> UpsertClusterAsync(KafkaClusterUpsertRequest request, CancellationToken cancellationToken = default)
     {
-        return ExecuteAsync(() => clusterService.UpsertClusterAsync(request.Cluster, cancellationToken), "Failed to save Kafka cluster");
+        return ExecuteAsync(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return clusterService.UpsertClusterAsync(request.Cluster, cancellationToken);
+        }, "Failed to save Kafka cluster");
     }
 
     /// <summary>
@@ -77,7 +81,11 @@ public sealed class KafkaConsoleFacade(
     /// </summary>
     public Task<Res> CreateTopicAsync(KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
     {
-        return ExecuteAsync(() => topicService.CreateTopicAsync(request, cancellationToken), "Kafka topic created", "Failed to create Kafka topic");
+        return ExecuteAsync(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return topicService.CreateTopicAsync(request, cancellationToken);
+        }, "Kafka topic created", "Failed to create Kafka topic");
     }
 
     /// <summary>
@@ -93,7 +101,11 @@ public sealed class KafkaConsoleFacade(
     /// </summary>
     public Task<Res> IncreasePartitionsAsync(KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default)
     {
-        return ExecuteAsync(() => topicService.IncreasePartitionsAsync(request, cancellationToken), "Kafka topic partitions updated", "Failed to update Kafka partitions");
+        return ExecuteAsync(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return topicService.IncreasePartitionsAsync(request, cancellationToken);
+        }, "Kafka topic partitions updated", "Failed to update Kafka partitions");
     }
 
     /// <summary>
@@ -101,7 +113,11 @@ public sealed class KafkaConsoleFacade(
     /// </summary>
     public Task<Res> UpdateRetentionAsync(KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default)
     {
-        return ExecuteAsync(() => topicService.UpdateRetentionAsync(request, cancellationToken), "Kafka topic retention updated", "Failed to update Kafka retention");
+        return ExecuteAsync(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return topicService.UpdateRetentionAsync(request, cancellationToken);
+        }, "Kafka topic retention updated", "Failed to update Kafka retention");
     }
 
     /// <summary>
@@ -109,7 +125,11 @@ public sealed class KafkaConsoleFacade(
     /// </summary>
     public Task<Res<KafkaTopicMessageBatch>> ReadTopicMessagesAsync(KafkaTopicMessagesRequest request, CancellationToken cancellationToken = default)
     {
-        return ExecuteAsync(() => topicService.ReadMessagesAsync(request, cancellationToken), "Failed to read Kafka topic messages");
+        return ExecuteAsync(() =>
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return topicService.ReadMessagesAsync(request, cancellationToken);
+        }, "Failed to read Kafka topic messages");
     }
 
     /// <summary>

--- a/Monica.EventBus.Kafka/Models/KafkaClusterConfig.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaClusterConfig.cs
@@ -95,7 +95,7 @@ public sealed class KafkaClusterConfig
             ? BuildClusterId(DisplayName, BootstrapServers)
             : ClusterId.Trim();
         DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? ClusterId : DisplayName.Trim();
-        BootstrapServers = BootstrapServers.Trim();
+        BootstrapServers = NormalizeRequired(BootstrapServers);
         ClientId = NormalizeOptional(ClientId);
         SecurityProtocol = NormalizeOptional(SecurityProtocol);
         SaslMechanism = NormalizeOptional(SaslMechanism);
@@ -135,7 +135,7 @@ public sealed class KafkaClusterConfig
     private static string BuildClusterId(string displayName, string bootstrapServers)
     {
         var source = !string.IsNullOrWhiteSpace(displayName) ? displayName : bootstrapServers;
-        var normalized = new string(source.Trim()
+        var normalized = new string(NormalizeRequired(source)
             .Select(ch => char.IsLetterOrDigit(ch) ? char.ToLowerInvariant(ch) : '-')
             .ToArray())
             .Trim('-');
@@ -145,6 +145,11 @@ public sealed class KafkaClusterConfig
     private static string? NormalizeOptional(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string NormalizeRequired(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
     }
 }
 

--- a/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
+++ b/Monica.EventBus.Kafka/Models/KafkaConsoleModels.cs
@@ -99,6 +99,17 @@ public sealed class KafkaBrokerInfo
 }
 
 /// <summary>
+/// Result of a direct Kafka connection test.
+/// </summary>
+public sealed class KafkaConnectionTestResult
+{
+    /// <summary>
+    /// Brokers returned by Kafka metadata.
+    /// </summary>
+    public IReadOnlyList<KafkaBrokerInfo> Brokers { get; set; } = [];
+}
+
+/// <summary>
 /// Kafka topic summary displayed in topic management.
 /// </summary>
 public sealed class KafkaTopicSummary

--- a/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
+++ b/Monica.EventBus.Kafka/Modules/ModuleEventBusKafka.cs
@@ -86,6 +86,7 @@ public sealed class ModuleEventBusKafka(ModuleEventBusKafkaOption option)
     {
         services.TryAddSingleton<IKafkaConsoleRepository, InMemoryKafkaConsoleRepository>();
         services.TryAddSingleton<IKafkaClusterConfigProvider, KafkaClusterConfigProvider>();
+        services.TryAddSingleton<KafkaBootstrapEndpointProbe>();
         services.TryAddScoped<IKafkaAdminProvider, ConfluentKafkaAdminProvider>();
         services.TryAddScoped<IKafkaMessageReader, ConfluentKafkaMessageReader>();
         services.TryAddScoped<IKafkaPerformanceMetricsProvider, ConfluentKafkaPerformanceMetricsProvider>();
@@ -429,6 +430,16 @@ public sealed class ModuleEventBusKafkaOption : MinimalApiModuleOptions<ModuleEv
     /// Gets or sets the request timeout used by Kafka admin operations.
     /// </summary>
     public TimeSpan AdminRequestTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets the managed TCP timeout used before creating native Kafka clients for console probes.
+    /// </summary>
+    /// <remarks>
+    /// The probe is a defensive preflight for user-entered bootstrap servers. When all endpoints
+    /// fail this check, the console reports the cluster as unreachable without constructing a
+    /// native Kafka client.
+    /// </remarks>
+    public TimeSpan BootstrapEndpointProbeTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Gets or sets the maximum time the native Kafka producer waits while flushing on disposal.

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaAdminProvider.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaAdminProvider.cs
@@ -15,31 +15,29 @@ internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOp
 {
     private ModuleEventBusKafkaOption Option => options.Value;
 
-    public Task TestConnectionAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
+    public Task<KafkaConnectionTestResult> TestConnectionAsync(
+        KafkaClusterConfig cluster,
+        CancellationToken cancellationToken = default)
     {
         using var admin = CreateAdminClient(cluster);
         var metadata = admin.GetMetadata(Option.AdminRequestTimeout);
-        if (metadata.Brokers.Count == 0)
+        var brokers = MapBrokers(metadata);
+        if (brokers.Count == 0)
         {
             throw new InvalidOperationException($"Kafka cluster '{cluster.ClusterId}' returned no brokers.");
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(new KafkaConnectionTestResult
+        {
+            Brokers = brokers
+        });
     }
 
     public Task<IReadOnlyList<KafkaBrokerInfo>> ListBrokersAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
     {
         using var admin = CreateAdminClient(cluster);
         var metadata = admin.GetMetadata(Option.AdminRequestTimeout);
-        var brokers = metadata.Brokers
-            .Select(broker => new KafkaBrokerInfo
-            {
-                BrokerId = broker.BrokerId,
-                Host = broker.Host,
-                Port = broker.Port
-            })
-            .OrderBy(broker => broker.BrokerId)
-            .ToList();
+        var brokers = MapBrokers(metadata);
         return Task.FromResult<IReadOnlyList<KafkaBrokerInfo>>(brokers);
     }
 
@@ -72,6 +70,7 @@ internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOp
 
     public async Task CreateTopicAsync(KafkaClusterConfig cluster, KafkaTopicCreateRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
         using var admin = CreateAdminClient(cluster);
 
@@ -103,6 +102,7 @@ internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOp
 
     public async Task IncreasePartitionsAsync(KafkaClusterConfig cluster, KafkaTopicPartitionRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
         if (request.IncreaseTo <= 0)
         {
@@ -126,6 +126,7 @@ internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOp
 
     public async Task UpdateRetentionAsync(KafkaClusterConfig cluster, KafkaTopicRetentionRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
         if (request.RetentionMs <= 0)
         {
@@ -204,6 +205,19 @@ internal sealed class ConfluentKafkaAdminProvider(IOptions<ModuleEventBusKafkaOp
         }
 
         return new AdminClientBuilder(KafkaClientConfigFactory.BuildAdminConfig(cluster, Option)).Build();
+    }
+
+    private static List<KafkaBrokerInfo> MapBrokers(Metadata metadata)
+    {
+        return metadata.Brokers
+            .Select(broker => new KafkaBrokerInfo
+            {
+                BrokerId = broker.BrokerId,
+                Host = broker.Host,
+                Port = broker.Port
+            })
+            .OrderBy(broker => broker.BrokerId)
+            .ToList();
     }
 
     private async Task<Dictionary<string, long?>> DescribeTopicRetentionsAsync(

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaMessageReader.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaMessageReader.cs
@@ -19,31 +19,35 @@ internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOp
 
     private ModuleEventBusKafkaOption Option => options.Value;
 
-    public Task<KafkaTopicMessageBatch> ReadMessagesAsync(
+    public async Task<KafkaTopicMessageBatch> ReadMessagesAsync(
         KafkaClusterConfig cluster,
         KafkaTopicMessagesRequest request,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TopicName);
 
         var maxMessages = Math.Clamp(request.MaxMessages, 1, Math.Max(1, Option.MessagePreviewMaxMessages));
         using var admin = CreateAdminClient(cluster);
-        using var consumer = CreateConsumer(cluster);
         var topicName = request.TopicName.Trim();
         var partitions = ResolvePartitions(admin, topicName);
-        var assignments = BuildAssignments(consumer, partitions, maxMessages);
-        var messages = assignments.Count == 0
-            ? []
-            : ConsumePreview(consumer, assignments, maxMessages, cancellationToken);
+        var watermarks = await ReadWatermarksAsync(admin, partitions, cancellationToken);
+        var assignments = BuildAssignments(watermarks, maxMessages);
+        IReadOnlyList<KafkaTopicMessageSample> messages = [];
+        if (assignments.Count > 0)
+        {
+            using var consumer = CreateConsumer(cluster);
+            messages = ConsumePreview(consumer, assignments, watermarks, maxMessages, cancellationToken);
+        }
 
-        return Task.FromResult(new KafkaTopicMessageBatch
+        return new KafkaTopicMessageBatch
         {
             ClusterId = cluster.ClusterId,
             TopicName = topicName,
             MaxMessages = maxMessages,
             CapturedAt = DateTimeOffset.UtcNow,
             Messages = messages
-        });
+        };
     }
 
     private IConsumer<byte[], byte[]> CreateConsumer(KafkaClusterConfig cluster)
@@ -88,17 +92,59 @@ internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOp
             .ToList();
     }
 
-    private IReadOnlyList<TopicPartitionOffset> BuildAssignments(
-        IConsumer<byte[], byte[]> consumer,
+    private async Task<Dictionary<TopicPartition, PartitionWatermark>> ReadWatermarksAsync(
+        IAdminClient admin,
         IReadOnlyList<TopicPartition> partitions,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var lowOffsets = await ReadOffsetsAsync(admin, partitions, OffsetSpec.Earliest());
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var highOffsets = await ReadOffsetsAsync(admin, partitions, OffsetSpec.Latest());
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return partitions
+            .Where(partition => lowOffsets.ContainsKey(partition) && highOffsets.ContainsKey(partition))
+            .ToDictionary(
+                partition => partition,
+                partition => new PartitionWatermark(lowOffsets[partition], highOffsets[partition]));
+    }
+
+    private async Task<Dictionary<TopicPartition, long>> ReadOffsetsAsync(
+        IAdminClient admin,
+        IReadOnlyList<TopicPartition> partitions,
+        OffsetSpec offsetSpec)
+    {
+        var specs = partitions.Select(partition => new TopicPartitionOffsetSpec
+        {
+            TopicPartition = partition,
+            OffsetSpec = offsetSpec
+        });
+
+        var result = await admin.ListOffsetsAsync(specs, new ListOffsetsOptions
+        {
+            RequestTimeout = Option.AdminRequestTimeout
+        });
+
+        return result.ResultInfos
+            .Where(info => info.TopicPartitionOffsetError.Error.Code == ErrorCode.NoError &&
+                           info.TopicPartitionOffsetError.Offset.Value >= 0)
+            .ToDictionary(
+                info => info.TopicPartitionOffsetError.TopicPartition,
+                info => info.TopicPartitionOffsetError.Offset.Value);
+    }
+
+    private static IReadOnlyList<TopicPartitionOffset> BuildAssignments(
+        IReadOnlyDictionary<TopicPartition, PartitionWatermark> watermarks,
         int maxMessages)
     {
-        var assignments = new List<TopicPartitionOffset>(partitions.Count);
-        foreach (var partition in partitions)
+        var assignments = new List<TopicPartitionOffset>(watermarks.Count);
+        foreach (var (partition, watermark) in watermarks)
         {
-            var watermark = consumer.QueryWatermarkOffsets(partition, Option.AdminRequestTimeout);
-            var low = watermark.Low.Value;
-            var high = watermark.High.Value;
+            var low = watermark.Low;
+            var high = watermark.High;
             if (high <= low)
             {
                 continue;
@@ -115,6 +161,7 @@ internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOp
     private IReadOnlyList<KafkaTopicMessageSample> ConsumePreview(
         IConsumer<byte[], byte[]> consumer,
         IReadOnlyList<TopicPartitionOffset> assignments,
+        IReadOnlyDictionary<TopicPartition, PartitionWatermark> watermarks,
         int maxMessages,
         CancellationToken cancellationToken)
     {
@@ -123,7 +170,7 @@ internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOp
         var results = new List<KafkaTopicMessageSample>(maxMessages);
         var highWatermarks = assignments.ToDictionary(
             assignment => assignment.TopicPartition,
-            assignment => consumer.QueryWatermarkOffsets(assignment.TopicPartition, Option.AdminRequestTimeout).High.Value);
+            assignment => watermarks[assignment.TopicPartition].High);
         var deadline = DateTimeOffset.UtcNow.Add(Option.MessagePreviewTimeout);
 
         while (results.Count < maxMessages &&
@@ -223,4 +270,6 @@ internal sealed class ConfluentKafkaMessageReader(IOptions<ModuleEventBusKafkaOp
     }
 
     private sealed record DecodedPayload(string? Text, string Encoding, bool IsTruncated);
+
+    private sealed record PartitionWatermark(long Low, long High);
 }

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaPerformanceMetricsProvider.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/ConfluentKafkaPerformanceMetricsProvider.cs
@@ -79,50 +79,54 @@ internal sealed class ConfluentKafkaPerformanceMetricsProvider(IOptions<ModuleEv
         IReadOnlyList<KafkaConsumerGroupSummary> consumerGroups,
         CancellationToken cancellationToken)
     {
+        var partitionList = partitions.ToList();
+        var requests = consumerGroups
+            .Where(group => !string.IsNullOrWhiteSpace(group.GroupId))
+            .Select(group => new ConsumerGroupTopicPartitions(group.GroupId, partitionList))
+            .ToList();
+        if (requests.Count == 0)
+        {
+            return new ConsumerOffsetTotals(null, null);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var results = await admin.ListConsumerGroupOffsetsAsync(
+                requests,
+                new ListConsumerGroupOffsetsOptions
+                {
+                    RequestTimeout = Option.AdminRequestTimeout,
+                    RequireStableOffsets = false
+                });
+
+            return CalculateConsumerOffsetTotals(results.SelectMany(result => result.Partitions), latestOffsets);
+        }
+        catch (ListConsumerGroupOffsetsException ex)
+        {
+            return CalculateConsumerOffsetTotals(ex.Results.SelectMany(result => result.Partitions), latestOffsets);
+        }
+    }
+
+    private static ConsumerOffsetTotals CalculateConsumerOffsetTotals(
+        IEnumerable<TopicPartitionOffsetError> partitions,
+        IReadOnlyDictionary<TopicPartition, long> latestOffsets)
+    {
         long committedTotal = 0;
         long lagTotal = 0;
         var hasConsumerOffsets = false;
 
-        foreach (var group in consumerGroups.Where(group => !string.IsNullOrWhiteSpace(group.GroupId)))
+        foreach (var partition in partitions)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
+            if (partition.Error.Code != ErrorCode.NoError || partition.Offset.Value < 0)
             {
-                var results = await admin.ListConsumerGroupOffsetsAsync(
-                    [new ConsumerGroupTopicPartitions(group.GroupId, partitions.ToList())],
-                    new ListConsumerGroupOffsetsOptions
-                    {
-                        RequestTimeout = Option.AdminRequestTimeout,
-                        RequireStableOffsets = false
-                    });
-
-                foreach (var partition in results.SelectMany(result => result.Partitions))
-                {
-                    if (partition.Error.Code != ErrorCode.NoError || partition.Offset.Value < 0)
-                    {
-                        continue;
-                    }
-
-                    hasConsumerOffsets = true;
-                    committedTotal += partition.Offset.Value;
-                    lagTotal += CalculateLag(partition, latestOffsets);
-                }
+                continue;
             }
-            catch (ListConsumerGroupOffsetsException ex)
-            {
-                foreach (var partition in ex.Results.SelectMany(result => result.Partitions))
-                {
-                    if (partition.Error.Code != ErrorCode.NoError || partition.Offset.Value < 0)
-                    {
-                        continue;
-                    }
 
-                    hasConsumerOffsets = true;
-                    committedTotal += partition.Offset.Value;
-                    lagTotal += CalculateLag(partition, latestOffsets);
-                }
-            }
+            hasConsumerOffsets = true;
+            committedTotal += partition.Offset.Value;
+            lagTotal += CalculateLag(partition, latestOffsets);
         }
 
         if (!hasConsumerOffsets)

--- a/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusSubscriptionHostedService.cs
+++ b/Monica.EventBus.Kafka/Providers/ConfluentKafka/KafkaEventBusSubscriptionHostedService.cs
@@ -49,7 +49,11 @@ internal sealed class KafkaEventBusSubscriptionHostedService(
             return Task.CompletedTask;
         }
 
-        consumer.Task = Task.Run(() => ConsumeAsync(consumer), CancellationToken.None);
+        consumer.Task = Task.Factory.StartNew(
+            () => ConsumeAsync(consumer),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
         RecordState($"Started Kafka consumer for topic {topicName}", HostedServiceState.Running);
         return Task.CompletedTask;
     }
@@ -97,9 +101,24 @@ internal sealed class KafkaEventBusSubscriptionHostedService(
 
     private async Task ConsumeAsync(TopicConsumer topicConsumer)
     {
+        try
+        {
+            await ConsumeTopicAsync(topicConsumer);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during unsubscribe and shutdown.
+        }
+        catch (Exception ex)
+        {
+            RecordState($"Kafka consumer stopped for topic {topicConsumer.TopicName}", HostedServiceState.Degraded, ex);
+        }
+    }
+
+    private async Task ConsumeTopicAsync(TopicConsumer topicConsumer)
+    {
         var cluster = clusterConfigProvider.GetDirectEventBusCluster();
         var consumerConfig = KafkaClientConfigFactory.BuildConsumerConfig(cluster, options.Value, ServiceKey);
-
         using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
         consumer.Subscribe(topicConsumer.TopicName);
 
@@ -135,7 +154,14 @@ internal sealed class KafkaEventBusSubscriptionHostedService(
             catch (Exception ex)
             {
                 RecordState($"Kafka consumer failed for topic {topicConsumer.TopicName}", HostedServiceState.Degraded, ex);
-                await Task.Delay(options.Value.ConsumerErrorBackoff, topicConsumer.CancellationTokenSource.Token);
+                try
+                {
+                    await Task.Delay(options.Value.ConsumerErrorBackoff, topicConsumer.CancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
         }
 

--- a/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
+++ b/Monica.EventBus.Kafka/Services/InMemoryKafkaConsoleRepository.cs
@@ -71,7 +71,7 @@ internal sealed class InMemoryKafkaConsoleRepository : IKafkaConsoleRepository
 
         lock (list)
         {
-            return Task.FromResult(list.OrderBy(snapshot => snapshot.CapturedAt).LastOrDefault() is { } snapshot
+            return Task.FromResult(list.LastOrDefault() is { } snapshot
                 ? CloneSnapshot(snapshot)
                 : null);
         }

--- a/Monica.EventBus.Kafka/Services/KafkaBootstrapEndpointProbe.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaBootstrapEndpointProbe.cs
@@ -1,0 +1,203 @@
+using System.Globalization;
+using System.Net.Sockets;
+using Monica.EventBus.Kafka.Models;
+using Microsoft.Extensions.Options;
+using Monica.Modules;
+
+namespace Monica.EventBus.Kafka.Services;
+
+/// <summary>
+/// Performs a managed TCP preflight against Kafka bootstrap endpoints before native clients are created.
+/// </summary>
+public sealed class KafkaBootstrapEndpointProbe(IOptions<ModuleEventBusKafkaOption> options)
+{
+    private const int DEFAULT_KAFKA_PORT = 9092;
+
+    /// <summary>
+    /// Tests whether at least one bootstrap endpoint accepts a TCP connection.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration to probe.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The preflight result.</returns>
+    public async Task<KafkaBootstrapEndpointProbeResult> ProbeAsync(
+        KafkaClusterConfig cluster,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+
+        IReadOnlyList<KafkaBootstrapEndpoint> endpoints;
+        try
+        {
+            endpoints = ParseEndpoints(cluster.BootstrapServers);
+        }
+        catch (FormatException ex)
+        {
+            return KafkaBootstrapEndpointProbeResult.Fail(ex.Message);
+        }
+
+        if (endpoints.Count == 0)
+        {
+            return KafkaBootstrapEndpointProbeResult.Fail("Kafka bootstrap servers are not configured.");
+        }
+
+        var errors = new List<string>(endpoints.Count);
+        foreach (var endpoint in endpoints)
+        {
+            try
+            {
+                await ProbeEndpointAsync(endpoint, cancellationToken);
+                return KafkaBootstrapEndpointProbeResult.Success(endpoint.DisplayName);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"{endpoint.DisplayName}: {ex.Message}");
+            }
+        }
+
+        return KafkaBootstrapEndpointProbeResult.Fail(
+            $"No Kafka bootstrap endpoint is reachable. {string.Join("; ", errors)}");
+    }
+
+    private async Task ProbeEndpointAsync(KafkaBootstrapEndpoint endpoint, CancellationToken cancellationToken)
+    {
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(options.Value.BootstrapEndpointProbeTimeout);
+
+        using var client = new TcpClient();
+        try
+        {
+            await client.ConnectAsync(endpoint.Host, endpoint.Port, timeoutSource.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException("TCP connection timed out.");
+        }
+    }
+
+    private static IReadOnlyList<KafkaBootstrapEndpoint> ParseEndpoints(string? bootstrapServers)
+    {
+        if (string.IsNullOrWhiteSpace(bootstrapServers))
+        {
+            return [];
+        }
+
+        return bootstrapServers
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseEndpoint)
+            .ToList();
+    }
+
+    private static KafkaBootstrapEndpoint ParseEndpoint(string value)
+    {
+        if (value.StartsWith("[", StringComparison.Ordinal))
+        {
+            return ParseBracketedEndpoint(value);
+        }
+
+        var separatorIndex = value.LastIndexOf(':');
+        if (separatorIndex < 0)
+        {
+            return new KafkaBootstrapEndpoint(value, DEFAULT_KAFKA_PORT);
+        }
+
+        var host = value[..separatorIndex].Trim();
+        var portText = value[(separatorIndex + 1)..].Trim();
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new FormatException($"Kafka bootstrap endpoint '{value}' does not define a host.");
+        }
+
+        return new KafkaBootstrapEndpoint(host, ParsePort(value, portText));
+    }
+
+    private static KafkaBootstrapEndpoint ParseBracketedEndpoint(string value)
+    {
+        var endBracketIndex = value.IndexOf(']', StringComparison.Ordinal);
+        if (endBracketIndex <= 1)
+        {
+            throw new FormatException($"Kafka bootstrap endpoint '{value}' is not a valid bracketed IPv6 endpoint.");
+        }
+
+        var host = value[1..endBracketIndex].Trim();
+        var remainder = value[(endBracketIndex + 1)..].Trim();
+        if (remainder.Length == 0)
+        {
+            return new KafkaBootstrapEndpoint(host, DEFAULT_KAFKA_PORT);
+        }
+
+        if (!remainder.StartsWith(":", StringComparison.Ordinal))
+        {
+            throw new FormatException($"Kafka bootstrap endpoint '{value}' has invalid text after the host.");
+        }
+
+        return new KafkaBootstrapEndpoint(host, ParsePort(value, remainder[1..].Trim()));
+    }
+
+    private static int ParsePort(string endpoint, string portText)
+    {
+        if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port) ||
+            port is <= 0 or > 65535)
+        {
+            throw new FormatException($"Kafka bootstrap endpoint '{endpoint}' does not define a valid TCP port.");
+        }
+
+        return port;
+    }
+
+    private sealed record KafkaBootstrapEndpoint(string Host, int Port)
+    {
+        public string DisplayName => $"{Host}:{Port}";
+    }
+}
+
+/// <summary>
+/// Result of a Kafka bootstrap endpoint preflight.
+/// </summary>
+public sealed class KafkaBootstrapEndpointProbeResult
+{
+    private KafkaBootstrapEndpointProbeResult(bool isReachable, string? endpoint, string? errorMessage)
+    {
+        IsReachable = isReachable;
+        Endpoint = endpoint;
+        ErrorMessage = errorMessage;
+    }
+
+    /// <summary>
+    /// Whether at least one endpoint accepted a TCP connection.
+    /// </summary>
+    public bool IsReachable { get; }
+
+    /// <summary>
+    /// First endpoint that accepted a TCP connection, when available.
+    /// </summary>
+    public string? Endpoint { get; }
+
+    /// <summary>
+    /// Failure details when no endpoint could be reached.
+    /// </summary>
+    public string? ErrorMessage { get; }
+
+    /// <summary>
+    /// Creates a successful probe result.
+    /// </summary>
+    /// <param name="endpoint">Reachable endpoint.</param>
+    /// <returns>A successful result.</returns>
+    public static KafkaBootstrapEndpointProbeResult Success(string endpoint)
+    {
+        return new KafkaBootstrapEndpointProbeResult(true, endpoint, null);
+    }
+
+    /// <summary>
+    /// Creates a failed probe result.
+    /// </summary>
+    /// <param name="errorMessage">Failure details.</param>
+    /// <returns>A failed result.</returns>
+    public static KafkaBootstrapEndpointProbeResult Fail(string errorMessage)
+    {
+        return new KafkaBootstrapEndpointProbeResult(false, null, errorMessage);
+    }
+}

--- a/Monica.EventBus.Kafka/Services/KafkaClusterService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaClusterService.cs
@@ -1,6 +1,7 @@
 using Monica.EventBus.Kafka.Abstractions;
 using Monica.EventBus.Kafka.Models;
 using Microsoft.Extensions.Options;
+using Monica.Core.Extensions;
 using Monica.Modules;
 
 namespace Monica.EventBus.Kafka.Services;
@@ -11,6 +12,7 @@ namespace Monica.EventBus.Kafka.Services;
 public sealed class KafkaClusterService(
     IKafkaConsoleRepository repository,
     IKafkaAdminProvider adminProvider,
+    KafkaBootstrapEndpointProbe bootstrapEndpointProbe,
     IOptions<ModuleEventBusKafkaOption> options)
 {
     public async Task<IReadOnlyList<KafkaClusterSummary>> ListClustersAsync(CancellationToken cancellationToken = default)
@@ -37,6 +39,52 @@ public sealed class KafkaClusterService(
                ?? throw new KeyNotFoundException($"Kafka cluster '{clusterId}' was not found.");
     }
 
+    /// <summary>
+    /// Gets a cluster that can be used for direct Kafka administration after a managed endpoint preflight.
+    /// </summary>
+    /// <param name="clusterId">Cluster identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The reachable direct Kafka cluster configuration.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the cluster does not expose direct Kafka access or none of its bootstrap endpoints is reachable.
+    /// </exception>
+    public async Task<KafkaClusterConfig> GetRequiredDirectAdminClusterAsync(
+        string clusterId,
+        CancellationToken cancellationToken = default)
+    {
+        var cluster = await GetRequiredClusterAsync(clusterId, cancellationToken);
+        await EnsureDirectKafkaAccessAsync(cluster, cancellationToken);
+        return cluster;
+    }
+
+    /// <summary>
+    /// Verifies that a cluster exposes direct Kafka access and at least one bootstrap endpoint accepts TCP connections.
+    /// </summary>
+    /// <param name="cluster">Cluster configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when direct Kafka access is unavailable or endpoint preflight fails.
+    /// </exception>
+    public async Task EnsureDirectKafkaAccessAsync(
+        KafkaClusterConfig cluster,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+
+        if (!cluster.HasDirectKafkaAccess)
+        {
+            throw new InvalidOperationException(
+                $"Kafka cluster '{cluster.ClusterId}' is visible but direct admin access is not configured.");
+        }
+
+        var preflight = await bootstrapEndpointProbe.ProbeAsync(cluster, cancellationToken);
+        if (!preflight.IsReachable)
+        {
+            throw new InvalidOperationException(
+                preflight.ErrorMessage ?? $"Kafka cluster '{cluster.ClusterId}' is not reachable.");
+        }
+    }
+
     public async Task<KafkaClusterSummary> UpsertClusterAsync(KafkaClusterConfig cluster, CancellationToken cancellationToken = default)
     {
         var normalized = NormalizeForPersistence(cluster);
@@ -53,8 +101,13 @@ public sealed class KafkaClusterService(
     public async Task<KafkaClusterSummary> TestConnectionAsync(string clusterId, CancellationToken cancellationToken = default)
     {
         var cluster = await GetRequiredClusterAsync(clusterId, cancellationToken);
-        await adminProvider.TestConnectionAsync(cluster, cancellationToken);
-        return await BuildSummaryAsync(cluster, refreshBrokerMetadata: true, cancellationToken);
+        var summary = await BuildSummaryAsync(cluster, refreshBrokerMetadata: true, cancellationToken);
+        if (!summary.IsReachable)
+        {
+            summary.ErrorMessage ??= $"Kafka cluster '{cluster.ClusterId}' is not reachable.";
+        }
+
+        return summary;
     }
 
     public async Task<IReadOnlyList<KafkaClusterConfig>> GetEffectiveClustersAsync(CancellationToken cancellationToken = default)
@@ -108,24 +161,68 @@ public sealed class KafkaClusterService(
             return summary;
         }
 
+        var preflight = await bootstrapEndpointProbe.ProbeAsync(summary.Config, cancellationToken);
+        if (!preflight.IsReachable)
+        {
+            summary.IsReachable = false;
+            summary.ErrorMessage = preflight.ErrorMessage;
+            return summary;
+        }
+
         try
         {
-            var brokers = await adminProvider.ListBrokersAsync(summary.Config, cancellationToken);
-            var topics = await adminProvider.ListTopicsAsync(summary.Config, cancellationToken);
-            var groups = await adminProvider.ListConsumerGroupsAsync(summary.Config, cancellationToken);
-
-            summary.IsReachable = brokers.Count > 0;
-            summary.BrokerCount = brokers.Count;
-            summary.TopicCount = topics.Count;
-            summary.ConsumerGroupCount = groups.Count;
+            var connection = await adminProvider.TestConnectionAsync(summary.Config, cancellationToken);
+            summary.IsReachable = true;
+            summary.BrokerCount = connection.Brokers.Count;
+            await TryPopulateInventoryCountsAsync(summary, cancellationToken);
         }
         catch (Exception ex)
         {
             summary.IsReachable = false;
-            summary.ErrorMessage = ex.Message;
+            summary.ErrorMessage = BuildConnectionErrorMessage(ex);
         }
 
         return summary;
+    }
+
+    private async Task TryPopulateInventoryCountsAsync(
+        KafkaClusterSummary summary,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var topics = await adminProvider.ListTopicsAsync(summary.Config, cancellationToken);
+            summary.TopicCount = topics.Count;
+        }
+        catch (Exception ex)
+        {
+            summary.ErrorMessage = $"Kafka connection succeeded, but topic metadata could not be read: {ex.GetMessageRecursively()}";
+        }
+
+        try
+        {
+            var groups = await adminProvider.ListConsumerGroupsAsync(summary.Config, cancellationToken);
+            summary.ConsumerGroupCount = groups.Count;
+        }
+        catch (Exception ex)
+        {
+            var groupError = $"consumer group metadata could not be read: {ex.GetMessageRecursively()}";
+            summary.ErrorMessage = string.IsNullOrWhiteSpace(summary.ErrorMessage)
+                ? $"Kafka connection succeeded, but {groupError}"
+                : $"{summary.ErrorMessage}; {groupError}";
+        }
+    }
+
+    private static string BuildConnectionErrorMessage(Exception exception)
+    {
+        var message = exception.GetMessageRecursively();
+        if (message.Contains("Local: Broker transport failure", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{message}. TCP reached the bootstrap endpoint, but Kafka metadata could not be read. " +
+                   "Check the broker advertised.listeners value, security protocol, SASL/SSL settings, and whether the advertised broker address is reachable from Monica.";
+        }
+
+        return message;
     }
 
     private static KafkaClusterConfig NormalizeForPersistence(KafkaClusterConfig cluster)

--- a/Monica.EventBus.Kafka/Services/KafkaConsumerGroupService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaConsumerGroupService.cs
@@ -14,13 +14,7 @@ public sealed class KafkaConsumerGroupService(
         string clusterId,
         CancellationToken cancellationToken = default)
     {
-        var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
-        if (!cluster.HasDirectKafkaAccess)
-        {
-            throw new InvalidOperationException(
-                $"Kafka cluster '{cluster.ClusterId}' is visible but direct consumer group access is not configured.");
-        }
-
+        var cluster = await clusterService.GetRequiredDirectAdminClusterAsync(clusterId, cancellationToken);
         return await adminProvider.ListConsumerGroupsAsync(cluster, cancellationToken);
     }
 }

--- a/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaPerformanceService.cs
@@ -53,6 +53,8 @@ public sealed class KafkaPerformanceService(
 
         try
         {
+            await clusterService.EnsureDirectKafkaAccessAsync(cluster, cancellationToken);
+
             var brokers = await adminProvider.ListBrokersAsync(cluster, cancellationToken);
             var topics = await adminProvider.ListTopicsAsync(cluster, cancellationToken);
             var groups = await adminProvider.ListConsumerGroupsAsync(cluster, cancellationToken);

--- a/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
+++ b/Monica.EventBus.Kafka/Services/KafkaTopicService.cs
@@ -49,13 +49,6 @@ public sealed class KafkaTopicService(
 
     private async Task<KafkaClusterConfig> GetAdminClusterAsync(string clusterId, CancellationToken cancellationToken)
     {
-        var cluster = await clusterService.GetRequiredClusterAsync(clusterId, cancellationToken);
-        if (!cluster.HasDirectKafkaAccess)
-        {
-            throw new InvalidOperationException(
-                $"Kafka cluster '{cluster.ClusterId}' is visible but direct admin access is not configured.");
-        }
-
-        return cluster;
+        return await clusterService.GetRequiredDirectAdminClusterAsync(clusterId, cancellationToken);
     }
 }

--- a/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
+++ b/Monica.EventBus.Kafka/Services/Support/KafkaClientConfigFactory.cs
@@ -64,12 +64,12 @@ internal static class KafkaClientConfigFactory
         config.ClientId = normalized.ClientId ?? option.ClientId;
         config.SocketTimeoutMs = (int)option.AdminRequestTimeout.TotalMilliseconds;
 
-        if (TryParseEnum<SecurityProtocol>(normalized.SecurityProtocol, out var securityProtocol))
+        if (TryParseEnum(normalized.SecurityProtocol, nameof(KafkaClusterConfig.SecurityProtocol), out SecurityProtocol securityProtocol))
         {
             config.SecurityProtocol = securityProtocol;
         }
 
-        if (TryParseEnum<SaslMechanism>(normalized.SaslMechanism, out var saslMechanism))
+        if (TryParseEnum(normalized.SaslMechanism, nameof(KafkaClusterConfig.SaslMechanism), out SaslMechanism saslMechanism))
         {
             config.SaslMechanism = saslMechanism;
         }
@@ -97,7 +97,7 @@ internal static class KafkaClientConfigFactory
             : $"{option.ConsumerGroupId}-{serviceKey}";
     }
 
-    private static bool TryParseEnum<TEnum>(string? value, out TEnum result) where TEnum : struct
+    private static bool TryParseEnum<TEnum>(string? value, string propertyName, out TEnum result) where TEnum : struct, Enum
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -105,6 +105,12 @@ internal static class KafkaClientConfigFactory
             return false;
         }
 
-        return Enum.TryParse(value, ignoreCase: true, out result);
+        if (Enum.TryParse(value, ignoreCase: true, out result))
+        {
+            return true;
+        }
+
+        throw new InvalidOperationException(
+            $"Kafka cluster {propertyName} value '{value}' is invalid. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
     }
 }

--- a/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
+++ b/Monica.EventBus.Kafka/UIEventBusKafka/State/EventBusKafkaPageState.cs
@@ -1,3 +1,4 @@
+using Monica.Core.Extensions;
 using Monica.Core.Results;
 using Monica.EventBus.Kafka.Facades;
 using Monica.EventBus.Kafka.Models;
@@ -68,7 +69,7 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
     /// <summary>
     /// Whether the selected cluster supports direct Kafka admin operations.
     /// </summary>
-    public bool CanAdminSelectedCluster => SelectedCluster?.Config.HasDirectKafkaAccess == true;
+    public bool CanAdminSelectedCluster => SelectedCluster?.IsReachable == true;
 
     /// <summary>
     /// Initializes all page data.
@@ -182,13 +183,24 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
     {
         return await RunAsync(async () =>
         {
-            if (!TryRead(await facade.TestClusterAsync(clusterId, cancellationToken), out _))
+            if (!TryRead(await facade.TestClusterAsync(clusterId, cancellationToken), out var summary))
             {
                 return false;
             }
 
-            await RefreshAsync(cancellationToken);
-            return true;
+            ApplyClusterSummary(summary);
+            if (summary.IsReachable)
+            {
+                await RefreshSelectedClusterDetailsIfSelectedAsync(
+                    summary.Config.ClusterId,
+                    cancellationToken,
+                    suppressErrors: true);
+                return true;
+            }
+
+            ClearSelectedClusterDetailsIfSelected(summary.Config.ClusterId);
+            ErrorMessage = summary.ErrorMessage ?? $"Kafka cluster '{summary.Config.DisplayName}' is not reachable.";
+            return false;
         });
     }
 
@@ -343,22 +355,79 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
         });
     }
 
-    private async Task RefreshSelectedClusterDetailsAsync(CancellationToken cancellationToken)
+    private async Task RefreshSelectedClusterDetailsAsync(CancellationToken cancellationToken, bool suppressErrors = false)
     {
-        if (SelectedClusterId is null || !CanAdminSelectedCluster)
+        if (SelectedClusterId is null || !ShouldLoadSelectedClusterDetails)
         {
-            Topics = [];
-            ConsumerGroups = [];
-            PerformanceSnapshots = [];
+            ClearSelectedClusterDetails();
             return;
         }
 
-        await RefreshTopicsAsync(cancellationToken);
-        await RefreshConsumerGroupsAsync(cancellationToken);
-        await RefreshPerformanceAsync(cancellationToken);
+        await RefreshTopicsAsync(cancellationToken, suppressErrors);
+        await RefreshConsumerGroupsAsync(cancellationToken, suppressErrors);
+        await RefreshPerformanceAsync(cancellationToken, suppressErrors);
     }
 
-    private async Task RefreshTopicsAsync(CancellationToken cancellationToken)
+    private async Task RefreshSelectedClusterDetailsIfSelectedAsync(
+        string clusterId,
+        CancellationToken cancellationToken,
+        bool suppressErrors = false)
+    {
+        if (!string.Equals(SelectedClusterId, clusterId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await RefreshSelectedClusterDetailsAsync(cancellationToken, suppressErrors);
+    }
+
+    private bool ShouldLoadSelectedClusterDetails =>
+        SelectedCluster?.Config.HasDirectKafkaAccess == true &&
+        SelectedCluster.IsReachable;
+
+    private void ClearSelectedClusterDetailsIfSelected(string clusterId)
+    {
+        if (string.Equals(SelectedClusterId, clusterId, StringComparison.Ordinal))
+        {
+            ClearSelectedClusterDetails();
+        }
+    }
+
+    private void ClearSelectedClusterDetails()
+    {
+        Topics = [];
+        ConsumerGroups = [];
+        PerformanceSnapshots = [];
+    }
+
+    private void ApplyClusterSummary(KafkaClusterSummary summary)
+    {
+        var index = Clusters.FindIndex(cluster =>
+            string.Equals(cluster.Config.ClusterId, summary.Config.ClusterId, StringComparison.Ordinal));
+        if (index >= 0)
+        {
+            Clusters[index] = summary;
+        }
+        else
+        {
+            Clusters.Add(summary);
+            Clusters = Clusters
+                .OrderBy(cluster => cluster.Config.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        if (!string.Equals(SelectedClusterId, summary.Config.ClusterId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Dashboard.SelectedCluster = summary;
+        Dashboard.BrokerCount = summary.BrokerCount;
+        Dashboard.TopicCount = summary.TopicCount;
+        Dashboard.ConsumerGroupCount = summary.ConsumerGroupCount;
+    }
+
+    private async Task RefreshTopicsAsync(CancellationToken cancellationToken, bool suppressErrors = false)
     {
         if (SelectedClusterId is null)
         {
@@ -366,13 +435,17 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
             return;
         }
 
-        if (TryRead(await facade.ListTopicsAsync(SelectedClusterId, cancellationToken), out var topics))
+        Topics = [];
+        var result = await facade.ListTopicsAsync(SelectedClusterId, cancellationToken);
+        if (suppressErrors
+                ? TryReadSilently(result, out var topics)
+                : TryRead(result, out topics))
         {
             Topics = topics.ToList();
         }
     }
 
-    private async Task RefreshConsumerGroupsAsync(CancellationToken cancellationToken)
+    private async Task RefreshConsumerGroupsAsync(CancellationToken cancellationToken, bool suppressErrors = false)
     {
         if (SelectedClusterId is null)
         {
@@ -380,13 +453,17 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
             return;
         }
 
-        if (TryRead(await facade.ListConsumerGroupsAsync(SelectedClusterId, cancellationToken), out var groups))
+        ConsumerGroups = [];
+        var result = await facade.ListConsumerGroupsAsync(SelectedClusterId, cancellationToken);
+        if (suppressErrors
+                ? TryReadSilently(result, out var groups)
+                : TryRead(result, out groups))
         {
             ConsumerGroups = groups.ToList();
         }
     }
 
-    private async Task RefreshPerformanceAsync(CancellationToken cancellationToken)
+    private async Task RefreshPerformanceAsync(CancellationToken cancellationToken, bool suppressErrors = false)
     {
         if (SelectedClusterId is null)
         {
@@ -394,7 +471,11 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
             return;
         }
 
-        if (TryRead(await facade.GetPerformanceHistoryAsync(SelectedClusterId, cancellationToken: cancellationToken), out var snapshots))
+        PerformanceSnapshots = [];
+        var result = await facade.GetPerformanceHistoryAsync(SelectedClusterId, cancellationToken: cancellationToken);
+        if (suppressErrors
+                ? TryReadSilently(result, out var snapshots)
+                : TryRead(result, out snapshots))
         {
             PerformanceSnapshots = snapshots.ToList();
         }
@@ -425,6 +506,10 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
         {
             await action();
         }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.GetMessageRecursively();
+        }
         finally
         {
             IsBusy = false;
@@ -438,6 +523,11 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
         try
         {
             return await action();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.GetMessageRecursively();
+            return false;
         }
         finally
         {
@@ -466,6 +556,18 @@ public sealed class EventBusKafkaPageState(KafkaConsoleFacade facade)
 
         data = default!;
         ErrorMessage = error.Message;
+        return false;
+    }
+
+    private static bool TryReadSilently<T>(Res<T> result, out T data)
+    {
+        if (!result.IsFailed(out _))
+        {
+            data = result.Data!;
+            return true;
+        }
+
+        data = default!;
         return false;
     }
 }


### PR DESCRIPTION
- limit connection tests to bootstrap preflight and Kafka broker metadata
- keep topic and consumer group inventory reads as best-effort diagnostics
- prevent failed detail refreshes from overriding successful test results
- surface clearer broker transport failure guidance for listener/protocol issues