### PR TITLE
fix(job-scheduler): resolve Cron description culture under invariant globalization

### DIFF
--- a/Monica.JobScheduler.UI/UIJobScheduler/Components/CronDescriptionBadge.razor
+++ b/Monica.JobScheduler.UI/UIJobScheduler/Components/CronDescriptionBadge.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @using Microsoft.JSInterop
 @using Monica.JobScheduler.UI.Localization
 
@@ -75,7 +74,7 @@
         }
 
         _session ??= new CronDescriptionSession(JsRuntime);
-        var fingerprint = $"{CultureInfo.CurrentUICulture.Name}\u001f{Expression}";
+        var fingerprint = $"{CronDescriptionSession.ResolveCultureName()}\u001f{Expression}";
         if (string.Equals(_fingerprint, fingerprint, StringComparison.Ordinal))
         {
             return;
@@ -134,7 +133,7 @@
         {
             results = await session.DescribeAsync(
                 [new CronDescriptionRequest(REQUEST_KEY, Expression)],
-                CultureInfo.CurrentUICulture.Name,
+                CronDescriptionSession.ResolveCultureName(),
                 _lifetimeCancellation.Token);
         }
         catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)

--- a/Monica.JobScheduler.UI/UIJobScheduler/Components/JobCatalogOperationalTable.razor.cs
+++ b/Monica.JobScheduler.UI/UIJobScheduler/Components/JobCatalogOperationalTable.razor.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
@@ -192,7 +191,7 @@ public partial class JobCatalogOperationalTable : IAsyncDisposable
 
     private void QueueCronDescriptionLoad(IReadOnlyList<JobOperationalSummary> summaries)
     {
-        var cultureName = CultureInfo.CurrentUICulture.Name;
+        var cultureName = CronDescriptionSession.ResolveCultureName();
         var fingerprint = string.Join(
             '\u001f',
             summaries
@@ -243,7 +242,7 @@ public partial class JobCatalogOperationalTable : IAsyncDisposable
         {
             results = await session.DescribeAsync(
                 requests,
-                CultureInfo.CurrentUICulture.Name,
+                CronDescriptionSession.ResolveCultureName(),
                 _lifetimeCancellation.Token);
         }
         catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)

--- a/Monica.JobScheduler.UI/UIJobScheduler/Components/OperationalPolicyScheduleEditor.razor.cs
+++ b/Monica.JobScheduler.UI/UIJobScheduler/Components/OperationalPolicyScheduleEditor.razor.cs
@@ -206,7 +206,7 @@ public partial class OperationalPolicyScheduleEditor : IAsyncDisposable
 
     private void QueueDescription()
     {
-        var fingerprint = $"{CultureInfo.CurrentUICulture.Name}\u001f{Draft.EffectiveExpression}";
+        var fingerprint = $"{CronDescriptionSession.ResolveCultureName()}\u001f{Draft.EffectiveExpression}";
         if (string.Equals(_descriptionFingerprint, fingerprint, StringComparison.Ordinal))
         {
             return;
@@ -240,7 +240,7 @@ public partial class OperationalPolicyScheduleEditor : IAsyncDisposable
         {
             results = await session.DescribeAsync(
                 [new CronDescriptionRequest(DESCRIPTION_KEY, Draft.EffectiveExpression)],
-                CultureInfo.CurrentUICulture.Name,
+                CronDescriptionSession.ResolveCultureName(),
                 _lifetimeCancellation.Token);
         }
         catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)

--- a/Monica.JobScheduler.UI/UIJobScheduler/Support/CronDescriptionSession.cs
+++ b/Monica.JobScheduler.UI/UIJobScheduler/Support/CronDescriptionSession.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.JSInterop;
 
 namespace Monica.JobScheduler.UI.UIJobScheduler.Support;
@@ -12,6 +13,17 @@ namespace Monica.JobScheduler.UI.UIJobScheduler.Support;
 internal sealed class CronDescriptionSession(IJSRuntime jsRuntime) : IAsyncDisposable
 {
     private const string MODULE_PATH = "./_content/Monica.JobScheduler.UI/js/cron-descriptions.js";
+    private const string FALLBACK_CULTURE_NAME = "en-US";
+
+    /// <summary>
+    /// Resolves the culture name sent with Cron-description requests. Hosts running under invariant globalization
+    /// expose an empty culture name, so they fall back to English instead of failing the description load.
+    /// </summary>
+    internal static string ResolveCultureName()
+    {
+        var cultureName = CultureInfo.CurrentUICulture.Name;
+        return string.IsNullOrWhiteSpace(cultureName) ? FALLBACK_CULTURE_NAME : cultureName;
+    }
 
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly object _disposeSync = new();

--- a/tests/Test.Monica.JobScheduler.UI/Support/CronDescriptionSessionTests.cs
+++ b/tests/Test.Monica.JobScheduler.UI/Support/CronDescriptionSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AwesomeAssertions;
 using Microsoft.JSInterop;
 using Monica.JobScheduler.UI.UIJobScheduler.Support;
@@ -9,6 +10,38 @@ public sealed class CronDescriptionSessionTests
 {
     private const string EXPECTED_MODULE_PATH =
         "./_content/Monica.JobScheduler.UI/js/cron-descriptions.js";
+
+    [Fact]
+    public void ResolveCultureName_WhenUiCultureIsInvariant_ShouldFallBackToEnglish()
+    {
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            CronDescriptionSession.ResolveCultureName().Should().Be("en-US");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+
+    [Fact]
+    public void ResolveCultureName_WhenUiCultureIsNamed_ShouldPassTheCultureThrough()
+    {
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("zh-CN");
+
+            CronDescriptionSession.ResolveCultureName().Should().Be("zh-CN");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
 
     [Fact]
     public void JavascriptModule_ShouldDescribeCronosDayFieldsWithLogicalAndSemantics()


### PR DESCRIPTION
## Problem

CI (ubuntu runner) failed 13 of 127 tests in `Test.Monica.JobScheduler.UI` — every failure was `ArgumentException: The value cannot be an empty string (Parameter 'cultureName')` thrown from `CronDescriptionSession.DescribeAsync`.

Hosts whose default UI culture is invariant (GitHub-hosted Linux runners map `LANG=C.UTF-8` to the invariant culture) expose an empty `CultureInfo.CurrentUICulture.Name`. Three components passed that value straight into the Cron-description path, so rendering the catalog table, schedule editor, or Cron badge crashed the page. This also affects real deployments running under invariant globalization.

## Fix

- Add `CronDescriptionSession.ResolveCultureName()`: returns `CurrentUICulture.Name`, falling back to `en-US` when it is empty (matching the JS side, which already defaults an empty culture to English).
- Use it in `JobCatalogOperationalTable`, `OperationalPolicyScheduleEditor`, and `CronDescriptionBadge` for both the description request and the cache fingerprint.
- Add regression tests covering the invariant fallback and named-culture pass-through.

## Verification

Reproduced the CI condition locally (invariant default UI culture with ICU intact):

| State | Result |
|---|---|
| Before fix | **13 failed / 114 passed — identical to CI** |
| After fix | **0 failed / 129 passed** |

- `dotnet build Monica.slnx -m` — 0 warnings, 0 errors
- `Test.Monica.JobScheduler.UI` under normal culture — 129 passed