### PR TITLE
fix(ui): refine configuration, service discovery, and repository layouts

### DIFF
--- a/Monica.Configuration.UI/Pages/ConfigurationHistoryPage.razor
+++ b/Monica.Configuration.UI/Pages/ConfigurationHistoryPage.razor
@@ -28,70 +28,73 @@
             <ConfigurationMetadataStoreDiagnosticAlert Diagnostic="@_metadataStoreDiagnostic" />
         }
 
-        <MudPaper Outlined="true" Class="pa-3">
-            <MudGrid Spacing="2">
-                <MudItem xs="12" md="3" lg="2">
-                    <MudSelect T="string"
-                               @bind-Value="_definitionKey"
-                               Label="@L["State:Columns:Definition"]"
-                               Variant="Variant.Outlined"
-                               Margin="Margin.Dense"
-                               Clearable="true">
-                        @foreach (var definition in _definitions)
-                        {
-                            <MudSelectItem T="string"
-                                           Value="@definition.DefinitionKey"
-                                           Disabled="@(!definition.CanManage)">
-                                @DefinitionFilterLabel(definition)
-                            </MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12" md="3" lg="3">
-                    <MudTextField T="string"
-                                  @bind-Value="_pathText"
-                                  Label="@L["Value:Path"]"
-                                  Variant="Variant.Outlined"
-                                  Margin="Margin.Dense" />
-                </MudItem>
-                <MudItem xs="12" md="2">
-                    <MudSelect T="string"
-                               @bind-Value="_targetFilter"
-                               ToStringFunc="TargetFilterText"
-                               Label="@L["History:Filters:Target"]"
-                               Variant="Variant.Outlined"
-                               Margin="Margin.Dense">
-                        <MudSelectItem T="string" Value="@TARGET_FILTER_ALL">@L["History:Filters:TargetAll"]</MudSelectItem>
-                        <MudSelectItem T="string" Value="@TARGET_FILTER_MONICA">@L["History:Filters:TargetMonica"]</MudSelectItem>
-                        <MudSelectItem T="string" Value="@TARGET_FILTER_EXTERNAL">@L["History:Filters:TargetExternal"]</MudSelectItem>
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12" md="2">
-                    <MudDatePicker @bind-Date="_fromDate"
-                                   Label="@L["History:Filters:From"]"
+        <div class="configuration-history-filters">
+            <MudPaper Outlined="true" Class="pa-3">
+                <MudGrid Spacing="2" Class="configuration-history-filter-grid">
+                    <MudItem xs="12" md="2" lg="2">
+                        <MudSelect T="string"
+                                   @bind-Value="_definitionKey"
+                                   Label="@L["State:Columns:Definition"]"
                                    Variant="Variant.Outlined"
                                    Margin="Margin.Dense"
-                                   Editable="true" />
-                </MudItem>
-                <MudItem xs="12" md="2">
-                    <MudDatePicker @bind-Date="_toDate"
-                                   Label="@L["History:Filters:To"]"
+                                   Clearable="true">
+                            @foreach (var definition in _definitions)
+                            {
+                                <MudSelectItem T="string"
+                                               Value="@definition.DefinitionKey"
+                                               Disabled="@(!definition.CanManage)">
+                                    @DefinitionFilterLabel(definition)
+                                </MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" md="2" lg="3">
+                        <MudTextField T="string"
+                                      @bind-Value="_pathText"
+                                      Label="@L["Value:Path"]"
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense" />
+                    </MudItem>
+                    <MudItem xs="12" md="2">
+                        <MudSelect T="string"
+                                   @bind-Value="_targetFilter"
+                                   ToStringFunc="TargetFilterText"
+                                   Label="@L["History:Filters:Target"]"
                                    Variant="Variant.Outlined"
-                                   Margin="Margin.Dense"
-                                   Editable="true" />
-                </MudItem>
-                <MudItem xs="12">
-                    <MudStack Row="true" Justify="Justify.FlexEnd">
-                        <MudButton Variant="Variant.Filled"
-                                   Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.Search"
-                                   OnClick="LoadAsync">
-                            @L["Common:Actions:Search"]
-                        </MudButton>
-                    </MudStack>
-                </MudItem>
-            </MudGrid>
-        </MudPaper>
+                                   Margin="Margin.Dense">
+                            <MudSelectItem T="string" Value="@TARGET_FILTER_ALL">@L["History:Filters:TargetAll"]</MudSelectItem>
+                            <MudSelectItem T="string" Value="@TARGET_FILTER_MONICA">@L["History:Filters:TargetMonica"]</MudSelectItem>
+                            <MudSelectItem T="string" Value="@TARGET_FILTER_EXTERNAL">@L["History:Filters:TargetExternal"]</MudSelectItem>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" md="2">
+                        <MudDatePicker @bind-Date="_fromDate"
+                                       Label="@L["History:Filters:From"]"
+                                       Variant="Variant.Outlined"
+                                       Margin="Margin.Dense"
+                                       Editable="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="2">
+                        <MudDatePicker @bind-Date="_toDate"
+                                       Label="@L["History:Filters:To"]"
+                                       Variant="Variant.Outlined"
+                                       Margin="Margin.Dense"
+                                       Editable="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="2" lg="1">
+                        <div class="configuration-history-filter-action">
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.Search"
+                                       FullWidth="true"
+                                       OnClick="LoadAsync">
+                                @L["Common:Actions:Search"]
+                            </MudButton>
+                        </div>
+                    </MudItem>
+                </MudGrid>
+            </MudPaper>
+        </div>
 
         <MudTabs Rounded="true" ApplyEffectsToContainer="true">
             <MudTabPanel Text="@L["History:Tabs:Mutations"]" Icon="@Icons.Material.Filled.List">
@@ -105,7 +108,8 @@
                 }
                 else
                 {
-                    <MudTable T="ConfigurationHistoryDisplayRow" Items="@_displayHistory" Dense="true" Hover="true" Elevation="0" Class="configuration-history-table">
+                    <div class="configuration-history-table-scroll">
+                    <MudTable T="ConfigurationHistoryDisplayRow" Items="@_displayHistory" Dense="true" Hover="true" Elevation="0">
                         <HeaderContent>
                             <MudTh>@L["History:Columns:Time"]</MudTh>
                             <MudTh>@L["State:Columns:Definition"]</MudTh>
@@ -194,6 +198,7 @@
                             </MudTd>
                         </RowTemplate>
                     </MudTable>
+                    </div>
                     @if (_historyHasMore)
                     {
                         <MudStack Row="true" Justify="Justify.Center" Class="mt-3">
@@ -218,6 +223,7 @@
                 }
                 else
                 {
+                    <div class="configuration-history-table-scroll">
                     <MudTable T="ConfigurationMutationGroup" Items="@_groups" Dense="true" Hover="true" Elevation="0">
                         <HeaderContent>
                             <MudTh>@L["Group:Label"]</MudTh>
@@ -275,6 +281,7 @@
                             </MudTd>
                         </RowTemplate>
                     </MudTable>
+                    </div>
                     @if (_groupsHaveMore)
                     {
                         <MudStack Row="true" Justify="Justify.Center" Class="mt-3">

--- a/Monica.Configuration.UI/Pages/ConfigurationHistoryPage.razor.css
+++ b/Monica.Configuration.UI/Pages/ConfigurationHistoryPage.razor.css
@@ -8,11 +8,49 @@
     padding-block: clamp(1rem, 2vw, 1.5rem);
 }
 
-.configuration-history-table ::deep .mud-chip {
+.configuration-history-filters,
+.configuration-history-table-scroll {
+    width: 100%;
+    min-width: 0;
+}
+
+.configuration-history-filters ::deep .mud-paper {
+    width: 100%;
+    min-width: 0;
+}
+
+.configuration-history-filters ::deep .configuration-history-filter-grid {
+    min-width: 0;
+}
+
+.configuration-history-filter-action {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+    padding-block: 0.5rem 0.25rem;
+}
+
+.configuration-history-filter-action ::deep .mud-button-root {
+    block-size: 2.5rem;
+    min-block-size: 2.5rem;
+}
+
+.configuration-history-table-scroll ::deep .mud-table {
+    width: 100%;
+    min-width: 0;
+}
+
+.configuration-history-table-scroll ::deep .mud-table-container {
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+.configuration-history-table-scroll ::deep .mud-chip {
     max-width: 100%;
 }
 
-.configuration-history-table ::deep .mud-table-cell {
+.configuration-history-table-scroll ::deep .mud-table-cell {
     vertical-align: middle;
 }
 
@@ -51,4 +89,10 @@
 
 .configuration-history-tooltip-lines > div + div {
     margin-top: 0.25rem;
+}
+
+@media (max-width: 599.98px) {
+    .configuration-history-filter-action {
+        padding-block: 0;
+    }
 }

--- a/Monica.Configuration.UI/Pages/ConfigurationStatePage.razor
+++ b/Monica.Configuration.UI/Pages/ConfigurationStatePage.razor
@@ -37,28 +37,30 @@
                         </div>
                     </TitleAccessory>
                     <Actions>
-                        <MudTooltip Text="@CatalogOperationTooltip("Common:Actions:Import")">
-                            <MudButton Variant="Variant.Outlined"
-                                       StartIcon="@Icons.Material.Filled.UploadFile"
-                                       Disabled="@(!CanUseCatalogOperations)"
-                                       OnClick="OpenImportDialog">
-                                @L["Common:Actions:Import"]
-                            </MudButton>
-                        </MudTooltip>
-                        <MudTooltip Text="@CatalogOperationTooltip("Common:Actions:Export")">
-                            <MudButton Variant="Variant.Outlined"
-                                       StartIcon="@Icons.Material.Filled.Download"
-                                       Disabled="@(!CanUseCatalogOperations)"
-                                       OnClick="() => OpenExportDialog(null, null)">
-                                @L["Common:Actions:Export"]
-                            </MudButton>
-                        </MudTooltip>
-                        <MudTooltip Text="@L["Common:Actions:Refresh"]">
-                            <MudIconButton Icon="@Icons.Material.Filled.Refresh"
-                                           Variant="Variant.Outlined"
-                                           OnClick="LoadDefinitionsAsync"
-                                           aria-label="@L["Common:Actions:Refresh"]" />
-                        </MudTooltip>
+                        <div class="configuration-state-actions">
+                            <MudTooltip Text="@CatalogOperationTooltip("Common:Actions:Import")">
+                                <MudButton Variant="Variant.Outlined"
+                                           StartIcon="@Icons.Material.Filled.UploadFile"
+                                           Disabled="@(!CanUseCatalogOperations)"
+                                           OnClick="OpenImportDialog">
+                                    @L["Common:Actions:Import"]
+                                </MudButton>
+                            </MudTooltip>
+                            <MudTooltip Text="@CatalogOperationTooltip("Common:Actions:Export")">
+                                <MudButton Variant="Variant.Outlined"
+                                           StartIcon="@Icons.Material.Filled.Download"
+                                           Disabled="@(!CanUseCatalogOperations)"
+                                           OnClick="() => OpenExportDialog(null, null)">
+                                    @L["Common:Actions:Export"]
+                                </MudButton>
+                            </MudTooltip>
+                            <MudTooltip Text="@L["Common:Actions:Refresh"]">
+                                <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                                               Variant="Variant.Outlined"
+                                               OnClick="LoadDefinitionsAsync"
+                                               aria-label="@L["Common:Actions:Refresh"]" />
+                            </MudTooltip>
+                        </div>
                     </Actions>
                 </ConfigurationPageHeader>
                 @if (!_loadingDefinitions)

--- a/Monica.Configuration.UI/Pages/ConfigurationStatePage.razor.css
+++ b/Monica.Configuration.UI/Pages/ConfigurationStatePage.razor.css
@@ -28,10 +28,6 @@
     overflow: hidden;
 }
 
-.configuration-state-page ::deep .configuration-state-header {
-    flex: 0 0 auto;
-}
-
 .configuration-state-header-shell,
 .configuration-runtime-validation-popover-anchor {
     width: 100%;
@@ -42,12 +38,28 @@
     flex: 0 0 auto;
 }
 
-.configuration-state-heading {
+.configuration-state-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     min-width: 0;
+    max-width: 100%;
 }
 
-.configuration-state-header-actions {
-    flex: 0 0 auto;
+.configuration-state-actions ::deep .mud-tooltip-root {
+    display: inline-flex;
+    align-items: center;
+}
+
+.configuration-state-actions ::deep .mud-button-root {
+    block-size: 2.5rem;
+    min-block-size: 2.5rem;
+}
+
+.configuration-state-actions ::deep .mud-icon-button {
+    inline-size: 2.5rem;
+    min-inline-size: 2.5rem;
 }
 
 .configuration-runtime-validation-popover-anchor {
@@ -319,20 +331,6 @@
 @media (max-width: 599.98px) {
     .configuration-state-page {
         padding-block: 1.25rem 1.5rem;
-    }
-
-    .configuration-state-page ::deep .configuration-state-header {
-        align-items: stretch;
-        gap: 1rem;
-    }
-
-    .configuration-state-heading,
-    .configuration-state-header-actions {
-        width: 100%;
-    }
-
-    .configuration-state-header-actions {
-        justify-content: flex-start;
     }
 
     .configuration-state-title-row {

--- a/Monica.Repository.UI/Pages/UIRepositoryDashboardPage.razor.css
+++ b/Monica.Repository.UI/Pages/UIRepositoryDashboardPage.razor.css
@@ -42,6 +42,27 @@
     justify-content: flex-end;
 }
 
+.detail-header__actions {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.detail-header__actions ::deep .mud-tooltip-root {
+    display: inline-flex;
+    flex: 0 0 auto;
+}
+
+.detail-header__actions ::deep .mud-button-root {
+    block-size: 2.5rem;
+    min-block-size: 2.5rem;
+    flex: 0 0 auto;
+}
+
+.detail-header__actions ::deep .mud-icon-button {
+    inline-size: 2.5rem;
+    min-inline-size: 2.5rem;
+}
+
 .dashboard-workspace {
     flex: 1 1 auto;
     min-height: 0;

--- a/Monica.Repository.UI/UIRepository/Components/RepositoryContextRail.razor.css
+++ b/Monica.Repository.UI/UIRepository/Components/RepositoryContextRail.razor.css
@@ -34,6 +34,7 @@
 }
 
 .context-list {
+    flex: 1 1 auto;
     min-height: 0;
     overflow: auto;
     display: flex;

--- a/Monica.ServiceDiscovery/Pages/UIServiceDiscoveryPage.razor.css
+++ b/Monica.ServiceDiscovery/Pages/UIServiceDiscoveryPage.razor.css
@@ -1,5 +1,7 @@
 .service-discovery-page {
+    max-width: 100%;
     min-height: 100%;
+    min-width: 0;
     width: 100%;
 }
 
@@ -120,8 +122,9 @@
 
 .service-discovery-page ::deep .service-discovery-tabs {
     background: transparent;
+    max-width: 100%;
     min-width: 0;
-    overflow: visible;
+    width: 100%;
 }
 
 .service-discovery-page ::deep .service-discovery-tabs > .mud-tabs-tabbar {
@@ -129,7 +132,19 @@
     border: 1px solid var(--mud-palette-divider);
     border-radius: 8px;
     box-shadow: 0 8px 24px color-mix(in srgb, var(--mud-palette-text-primary) 5%, transparent);
+    max-width: 100%;
+    min-width: 0;
     padding: 0.375rem;
+}
+
+.service-discovery-page ::deep .service-discovery-tabs .mud-tabs-tabbar-inner,
+.service-discovery-page ::deep .service-discovery-tabs .mud-tabs-tabbar-content {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.service-discovery-page ::deep .service-discovery-tabs .mud-tabs-tabbar-content {
+    overflow: hidden;
 }
 
 .service-discovery-page ::deep .service-discovery-tabs .mud-tabs-tabbar-wrapper {
@@ -160,12 +175,22 @@
 }
 
 .service-discovery-page ::deep .service-discovery-tabs > .mud-tabs-panels > .mud-tab-panel {
+    max-width: 100%;
+    min-width: 0;
     padding: 0;
 }
 
+.service-discovery-page ::deep .service-discovery-tabs > .mud-tabs-panels {
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
 .tab-content-panel {
+    max-width: 100%;
     min-width: 0;
     padding-top: 1.25rem;
+    width: 100%;
 }
 
 .service-discovery-section {
@@ -276,7 +301,6 @@
 
     .service-discovery-page ::deep .service-discovery-tabs > .mud-tabs-tabbar {
         border-radius: 6px;
-        margin-inline: -0.25rem;
     }
 
     .service-discovery-page ::deep .service-discovery-tabs .mud-tab {

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainDetail.razor
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainDetail.razor
@@ -8,150 +8,159 @@
 @inject ISnackbar Snackbar
 @inject IStringLocalizer<ServiceDiscoveryResource> L
 
-@if (_domainDetail != null)
-{
-    <MudStack Spacing="4">
-        <MudPaper Class="pa-4">
-            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
-                    <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack" OnClick="OnBackClick">
-                        @L["DomainDetail:Actions:BackToList"]
+<div class="domain-detail">
+    @if (_domainDetail != null)
+    {
+        <MudStack Spacing="4">
+            <MudPaper Class="pa-4 domain-detail__section">
+                <div class="domain-detail__header-row">
+                    <div class="domain-detail__header-main">
+                        <MudButton Class="domain-detail__back"
+                                   Variant="Variant.Text"
+                                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                                   OnClick="OnBackClick">
+                            @L["DomainDetail:Actions:BackToList"]
+                        </MudButton>
+                        <MudDivider Class="domain-detail__header-divider" Vertical="true" FlexItem="false" />
+                        <div class="domain-detail__identity">
+                            <MudAvatar Class="@GetDomainAvatarClass()">
+                                <MudIcon Icon="@Icons.Material.Filled.Domain" />
+                            </MudAvatar>
+                            <div class="domain-detail__copy">
+                                <MudText Typo="Typo.h5" Class="domain-detail__title">@(_domainDetail.Domain.DisplayName ?? _domainDetail.Domain.Name)</MudText>
+                                @if (!string.IsNullOrEmpty(_domainDetail.Domain.Description))
+                                {
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="domain-detail__description">@_domainDetail.Domain.Description</MudText>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                    <MudButton Class="domain-detail__refresh"
+                               Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               OnClick="RefreshDomainDetailAsync"
+                               Disabled="@_isLoading">
+                        <MudIcon Icon="@Icons.Material.Filled.Refresh" Class="mr-1" />
+                        @L["Shared:Actions:Refresh"]
                     </MudButton>
-                    <MudDivider Vertical="true" FlexItem="false" />
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudAvatar Class="@GetDomainAvatarClass()">
-                            <MudIcon Icon="@Icons.Material.Filled.Domain" />
-                        </MudAvatar>
-                        <MudStack Spacing="0">
-                            <MudText Typo="Typo.h5">@(_domainDetail.Domain.DisplayName ?? _domainDetail.Domain.Name)</MudText>
-                            @if (!string.IsNullOrEmpty(_domainDetail.Domain.Description))
-                            {
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@_domainDetail.Domain.Description</MudText>
-                            }
+                </div>
+            </MudPaper>
+
+            <MudGrid Class="domain-detail__grid">
+                <MudItem xs="12" md="4">
+                    <MudPaper Class="pa-4 domain-detail__section">
+                        <MudStack Spacing="3">
+                            <MudText Typo="Typo.h6">@L["DomainDetail:Sections:BasicInfo"]</MudText>
+                            <MudDivider />
+                            <MudStack Spacing="2">
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" Class="domain-detail__field-row">
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:Name"]</MudText>
+                                    <MudText Typo="Typo.body2">@_domainDetail.Domain.Name</MudText>
+                                </MudStack>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" Class="domain-detail__field-row">
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:DisplayName"]</MudText>
+                                    <MudText Typo="Typo.body2">@(_domainDetail.Domain.DisplayName ?? L["Shared:Values:NotSet"].Value)</MudText>
+                                </MudStack>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" Class="domain-detail__field-row">
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:OwnedServices"]</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Text="@L["DomainDetail:Counts:Services", GetOwnedServicesCount()]" />
+                                </MudStack>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" Class="domain-detail__field-row">
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:DependentServices"]</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Text="@L["DomainDetail:Counts:Services", GetDependentServicesCount()]" />
+                                </MudStack>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" Class="domain-detail__field-row">
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:RunningServices"]</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Text="@L["DomainDetail:Counts:Services", GetRunningServicesCount()]" />
+                                </MudStack>
+                            </MudStack>
                         </MudStack>
-                    </MudStack>
-                </MudStack>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="RefreshDomainDetailAsync" Disabled="@_isLoading">
-                    <MudIcon Icon="@Icons.Material.Filled.Refresh" Class="mr-1" />
-                    @L["Shared:Actions:Refresh"]
-                </MudButton>
-            </MudStack>
+                    </MudPaper>
+                </MudItem>
+
+                <MudItem xs="12" md="8">
+                    <MudPaper Class="pa-4 domain-detail__section">
+                        <MudStack Spacing="3">
+                            <MudTabs Elevation="0" Rounded="true" TabPanelsClass="pa-0" Class="domain-detail__tabs">
+                                <MudTabPanel Text="@L["DomainDetail:Tabs:OwnedServices", GetOwnedServicesCount()]">
+                                    <MudStack Spacing="3" Class="mt-3">
+                                        @if (_isLoading)
+                                        {
+                                            <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+                                            <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingServices"]</MudText>
+                                        }
+                                        else
+                                        {
+                                            var ownedServices = GetOwnedServices();
+                                            @if (!ownedServices.Any())
+                                            {
+                                                <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Secondary">
+                                                    @L["DomainDetail:States:NoOwnedServices"]
+                                                </MudText>
+                                            }
+                                            else
+                                            {
+                                                <MudStack Spacing="2">
+                                                    @foreach (var service in ownedServices)
+                                                    {
+                                                        @RenderServiceCard(service, true)
+                                                    }
+                                                </MudStack>
+                                            }
+                                        }
+                                    </MudStack>
+                                </MudTabPanel>
+                                <MudTabPanel Text="@L["DomainDetail:Tabs:DependentServices", GetDependentServicesCount()]">
+                                    <MudStack Spacing="3" Class="mt-3">
+                                        @if (_isLoading)
+                                        {
+                                            <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+                                            <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingServices"]</MudText>
+                                        }
+                                        else
+                                        {
+                                            var dependentServices = GetDependentServices();
+                                            @if (!dependentServices.Any())
+                                            {
+                                                <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Secondary">
+                                                    @L["DomainDetail:States:NoDependentServices"]
+                                                </MudText>
+                                            }
+                                            else
+                                            {
+                                                <MudStack Spacing="2">
+                                                    @foreach (var service in dependentServices)
+                                                    {
+                                                        @RenderServiceCard(service, false)
+                                                    }
+                                                </MudStack>
+                                            }
+                                        }
+                                    </MudStack>
+                                </MudTabPanel>
+                            </MudTabs>
+                        </MudStack>
+                    </MudPaper>
+                </MudItem>
+            </MudGrid>
+        </MudStack>
+    }
+    else if (_isLoading)
+    {
+        <MudPaper Class="pa-4 domain-detail__section">
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+            <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingDetail"]</MudText>
         </MudPaper>
-
-        <MudGrid>
-            <MudItem xs="12" md="4">
-                <MudPaper Class="pa-4">
-                    <MudStack Spacing="3">
-                        <MudText Typo="Typo.h6">@L["DomainDetail:Sections:BasicInfo"]</MudText>
-                        <MudDivider />
-                        <MudStack Spacing="2">
-                            <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:Name"]</MudText>
-                                <MudText Typo="Typo.body2">@_domainDetail.Domain.Name</MudText>
-                            </MudStack>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:DisplayName"]</MudText>
-                                <MudText Typo="Typo.body2">@(_domainDetail.Domain.DisplayName ?? L["Shared:Values:NotSet"].Value)</MudText>
-                            </MudStack>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:OwnedServices"]</MudText>
-                                <MudChip T="string" Size="Size.Small" Color="Color.Primary" Text="@L["DomainDetail:Counts:Services", GetOwnedServicesCount()]" />
-                            </MudStack>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:DependentServices"]</MudText>
-                                <MudChip T="string" Size="Size.Small" Color="Color.Info" Text="@L["DomainDetail:Counts:Services", GetDependentServicesCount()]" />
-                            </MudStack>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["DomainDetail:Fields:RunningServices"]</MudText>
-                                <MudChip T="string" Size="Size.Small" Color="Color.Success" Text="@L["DomainDetail:Counts:Services", GetRunningServicesCount()]" />
-                            </MudStack>
-                        </MudStack>
-                    </MudStack>
-                </MudPaper>
-            </MudItem>
-
-            <MudItem xs="12" md="8">
-                <MudPaper Class="pa-4">
-                    <MudStack Spacing="3">
-                        <MudTabs Elevation="0" Rounded="true" TabPanelsClass="pa-0">
-                            <MudTabPanel Text="@L["DomainDetail:Tabs:OwnedServices", GetOwnedServicesCount()]">
-                                <MudStack Spacing="3" Class="mt-3">
-                                    @if (_isLoading)
-                                    {
-                                        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
-                                        <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingServices"]</MudText>
-                                    }
-                                    else
-                                    {
-                                        var ownedServices = GetOwnedServices();
-                                        @if (!ownedServices.Any())
-                                        {
-                                            <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Secondary">
-                                                @L["DomainDetail:States:NoOwnedServices"]
-                                            </MudText>
-                                        }
-                                        else
-                                        {
-                                            <MudStack Spacing="2">
-                                                @foreach (var service in ownedServices)
-                                                {
-                                                    @RenderServiceCard(service, true)
-                                                }
-                                            </MudStack>
-                                        }
-                                    }
-                                </MudStack>
-                            </MudTabPanel>
-                            <MudTabPanel Text="@L["DomainDetail:Tabs:DependentServices", GetDependentServicesCount()]">
-                                <MudStack Spacing="3" Class="mt-3">
-                                    @if (_isLoading)
-                                    {
-                                        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
-                                        <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingServices"]</MudText>
-                                    }
-                                    else
-                                    {
-                                        var dependentServices = GetDependentServices();
-                                        @if (!dependentServices.Any())
-                                        {
-                                            <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Secondary">
-                                                @L["DomainDetail:States:NoDependentServices"]
-                                            </MudText>
-                                        }
-                                        else
-                                        {
-                                            <MudStack Spacing="2">
-                                                @foreach (var service in dependentServices)
-                                                {
-                                                    @RenderServiceCard(service, false)
-                                                }
-                                            </MudStack>
-                                        }
-                                    }
-                                </MudStack>
-                            </MudTabPanel>
-                        </MudTabs>
-                    </MudStack>
-                </MudPaper>
-            </MudItem>
-        </MudGrid>
-    </MudStack>
-}
-else if (_isLoading)
-{
-    <MudPaper Class="pa-4">
-        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
-        <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-2">@L["DomainDetail:States:LoadingDetail"]</MudText>
-    </MudPaper>
-}
-else
-{
-    <MudPaper Class="pa-4">
-        <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Error">
-            @L["DomainDetail:States:LoadFailed"]
-        </MudText>
-    </MudPaper>
-}
+    }
+    else
+    {
+        <MudPaper Class="pa-4 domain-detail__section">
+            <MudText Typo="Typo.body1" Align="Align.Center" Color="Color.Error">
+                @L["DomainDetail:States:LoadFailed"]
+            </MudText>
+        </MudPaper>
+    }
+</div>
 
 @code {
     [Parameter] public required string DomainName { get; set; }
@@ -251,53 +260,53 @@ else
 
     private RenderFragment RenderServiceCard(RegisteredServiceStatus service, bool isOwnedService) => @<MudCard Elevation="2" Class="service-card">
         <MudCardContent Class="pa-3">
-            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudText Typo="Typo.h6">@service.AppName</MudText>
+            <div class="domain-service-card__layout">
+                <div class="domain-service-card__main">
+                    <div class="domain-service-card__heading">
+                        <MudText Typo="Typo.h6" Class="domain-service-card__title">@service.AppName</MudText>
                         <MudChip T="string" Size="Size.Small" Color="@service.OverallStatus.GetColor()" Text="@service.OverallStatus.GetText(L)" />
                         @if (!isOwnedService)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Info" Text="@L["DomainDetail:ServiceCard:ExternalDependency"]" />
                         }
-                    </MudStack>
-                    <MudStack Spacing="0">
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    </div>
+                    <div class="domain-service-card__metadata">
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="domain-service-card__text">
                             @L["DomainDetail:ServiceCard:Id", service.AppId]
                         </MudText>
                         @if (!string.IsNullOrEmpty(service.DomainName))
                         {
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="domain-service-card__text">
                                 @L["DomainDetail:ServiceCard:Domain", service.DomainName]
                             </MudText>
                         }
                         @if (!string.IsNullOrEmpty(service.ProjectName))
                         {
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="domain-service-card__text">
                                 @L["DomainDetail:ServiceCard:Project", service.ProjectName]
                             </MudText>
                         }
-                    </MudStack>
+                    </div>
                     @if (service.DependentSubDomains?.Any() == true)
                     {
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <div class="domain-service-card__dependencies">
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@L["DomainDetail:ServiceCard:DependentSubDomains"]</MudText>
                             @foreach (var subDomain in service.DependentSubDomains)
                             {
                                 <MudChip T="string" Size="Size.Small" Color="@(subDomain == DomainName ? Color.Warning : Color.Surface)" Text="@subDomain" />
                             }
-                        </MudStack>
+                        </div>
                     }
-                </MudStack>
-                <MudStack AlignItems="AlignItems.End" Spacing="1">
+                </div>
+                <div class="domain-service-card__actions">
                     <MudText Typo="Typo.body2" Color="Color.Secondary">
                         @L["DomainDetail:ServiceCard:InstancesRunning", service.RunningInstanceCount, service.TotalInstanceCount]
                     </MudText>
                     <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="() => HandleServiceDetailClick(service)">
                         @L["Shared:Actions:ViewDetails"]
                     </MudButton>
-                </MudStack>
-            </MudStack>
+                </div>
+            </div>
         </MudCardContent>
     </MudCard>;
 

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainDetail.razor.css
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainDetail.razor.css
@@ -1,35 +1,232 @@
-.domain-avatar {
+.domain-detail {
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
+.domain-detail ::deep > .mud-stack,
+.domain-detail ::deep .domain-detail__section,
+.domain-detail ::deep .domain-detail__grid,
+.domain-detail ::deep .domain-detail__tabs,
+.domain-detail ::deep .domain-detail__tabs > .mud-tabs-panels,
+.domain-detail ::deep .domain-detail__tabs > .mud-tabs-panels > .mud-tab-panel {
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
+.domain-detail ::deep .domain-detail__grid > .mud-grid-item {
+    min-width: 0;
+}
+
+.domain-detail__header-row {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    min-width: 0;
+}
+
+.domain-detail__header-main {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    gap: 1rem;
+    min-width: 0;
+}
+
+.domain-detail__identity {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.domain-detail__copy,
+.domain-service-card__main {
+    min-width: 0;
+}
+
+.domain-detail ::deep .domain-detail__back,
+.domain-detail ::deep .domain-detail__refresh {
+    flex: 0 0 auto;
+    min-height: 2.5rem;
+    white-space: nowrap;
+}
+
+.domain-detail ::deep .domain-detail__header-divider {
+    flex: 0 0 auto;
+}
+
+.domain-detail ::deep .domain-detail__title,
+.domain-detail ::deep .domain-detail__description,
+.domain-detail ::deep .domain-service-card__title,
+.domain-detail ::deep .domain-service-card__text,
+.domain-detail ::deep .domain-service-card__actions .mud-typography {
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.domain-detail ::deep .domain-detail__field-row {
+    align-items: flex-start;
+    gap: 1rem;
+    min-width: 0;
+}
+
+.domain-detail ::deep .domain-detail__field-row > * {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.domain-detail ::deep .domain-detail__field-row > .mud-typography:last-child {
+    flex: 1 1 auto;
+    overflow-wrap: anywhere;
+    text-align: end;
+}
+
+.domain-detail ::deep .domain-detail__field-row > .mud-chip {
+    flex: 0 0 auto;
+    margin: 0;
+}
+
+.domain-detail ::deep .domain-detail__tabs .mud-tabs-tabbar-content {
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.domain-service-card__layout {
+    align-items: center;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    min-width: 0;
+}
+
+.domain-service-card__heading,
+.domain-service-card__dependencies {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.domain-service-card__metadata {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.domain-service-card__dependencies {
+    margin-top: 0.5rem;
+}
+
+.domain-service-card__actions {
+    align-items: flex-end;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    max-width: 100%;
+    min-width: 0;
+    text-align: end;
+}
+
+.domain-service-card__dependencies ::deep .mud-chip {
+    height: auto;
+    margin: 0;
+    max-width: 100%;
+    min-height: 1.5rem;
+}
+
+.domain-service-card__dependencies ::deep .mud-chip-content {
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+.domain-detail ::deep .domain-avatar {
     background: var(--domain-avatar-color);
     color: var(--mud-palette-primary-text);
 }
 
-.domain-avatar--primary { --domain-avatar-color: var(--mud-palette-primary); }
-.domain-avatar--secondary { --domain-avatar-color: var(--mud-palette-secondary); }
-.domain-avatar--tertiary { --domain-avatar-color: var(--mud-palette-tertiary); }
-.domain-avatar--info { --domain-avatar-color: var(--mud-palette-info); }
-.domain-avatar--success { --domain-avatar-color: var(--mud-palette-success); }
-.domain-avatar--warning { --domain-avatar-color: var(--mud-palette-warning); }
-.domain-avatar--default { --domain-avatar-color: var(--mud-palette-text-secondary); }
+.domain-detail ::deep .domain-avatar--primary { --domain-avatar-color: var(--mud-palette-primary); }
+.domain-detail ::deep .domain-avatar--secondary { --domain-avatar-color: var(--mud-palette-secondary); }
+.domain-detail ::deep .domain-avatar--tertiary { --domain-avatar-color: var(--mud-palette-tertiary); }
+.domain-detail ::deep .domain-avatar--info { --domain-avatar-color: var(--mud-palette-info); }
+.domain-detail ::deep .domain-avatar--success { --domain-avatar-color: var(--mud-palette-success); }
+.domain-detail ::deep .domain-avatar--warning { --domain-avatar-color: var(--mud-palette-warning); }
+.domain-detail ::deep .domain-avatar--default { --domain-avatar-color: var(--mud-palette-text-secondary); }
 
-::deep .service-card {
+.domain-detail ::deep .service-card {
     border: 1px solid var(--mud-palette-divider);
     border-radius: 8px;
     box-shadow: none;
-    transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+    max-width: 100%;
+    min-width: 0;
+    transition: border-color 180ms ease, box-shadow 180ms ease;
+    width: 100%;
 }
 
-::deep .service-card:hover {
+.domain-detail ::deep .service-card .mud-card-content {
+    min-width: 0;
+}
+
+.domain-detail ::deep .service-card:hover {
     border-color: color-mix(in srgb, var(--mud-palette-primary) 32%, var(--mud-palette-divider));
-    transform: translateY(-1px);
     box-shadow: 0 10px 24px color-mix(in srgb, var(--mud-palette-text-primary) 7%, transparent) !important;
 }
 
-@media (prefers-reduced-motion: reduce) {
-    ::deep .service-card {
-        transition: none;
+@media (max-width: 599.98px) {
+    .domain-detail__header-row,
+    .domain-detail__header-main {
+        align-items: stretch;
+        flex-direction: column;
     }
 
-    ::deep .service-card:hover {
-        transform: none;
+    .domain-detail__header-main {
+        gap: 0.75rem;
+    }
+
+    .domain-detail__identity {
+        align-items: flex-start;
+    }
+
+    .domain-detail ::deep .domain-detail__back {
+        align-self: flex-start;
+    }
+
+    .domain-detail ::deep .domain-detail__header-divider {
+        display: none;
+    }
+
+    .domain-detail ::deep .domain-detail__refresh {
+        width: 100%;
+    }
+
+    .domain-detail ::deep .domain-detail__field-row {
+        flex-direction: column !important;
+        gap: 0.25rem;
+    }
+
+    .domain-detail ::deep .domain-detail__field-row > .mud-typography:last-child {
+        text-align: start;
+    }
+
+    .domain-service-card__layout {
+        align-items: stretch;
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .domain-service-card__actions {
+        align-items: flex-start;
+        text-align: start;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .domain-detail ::deep .service-card {
+        transition: none !important;
     }
 }

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainList.razor
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainList.razor
@@ -8,15 +8,15 @@
 @inject ISnackbar Snackbar
 @inject IStringLocalizer<ServiceDiscoveryResource> L
 
-<MudStack Spacing="4" Class="domain-list">
+<div class="domain-list">
     <MudPaper Class="domain-list__header" Elevation="0" Outlined="true">
-        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+        <div class="domain-list__header-row">
             <MudText Typo="Typo.h6">@L["DomainList:Title"]</MudText>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="RefreshDomainsAsync" Disabled="@_isLoading">
                 <MudIcon Icon="@Icons.Material.Filled.Refresh" Class="mr-1" />
                 @L["Shared:Actions:Refresh"]
             </MudButton>
-        </MudStack>
+        </div>
     </MudPaper>
 
     @if (_isLoading)
@@ -49,7 +49,7 @@
                              @onkeydown="args => HandleDomainKeyDownAsync(args, domain)">
                         <MudCardContent>
                             <MudStack Spacing="2">
-                                <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                                <div class="domain-card__header">
                                     <div class="domain-card__identity">
                                         <span class="domain-card__icon" aria-hidden="true">
                                             <MudIcon Icon="@Icons.Material.Filled.Domain" />
@@ -58,14 +58,14 @@
                                             @(domain.DisplayName ?? domain.Name)
                                         </MudText>
                                     </div>
-                                    <MudStack AlignItems="AlignItems.End" Spacing="1">
+                                    <div class="domain-card__counts">
                                         <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Text="@L["DomainList:Counts:OwnedServices", GetOwnedServiceCount(domain.Name)]" />
                                         @if (GetRelatedServiceCount(domain.Name) > 0)
                                         {
                                             <MudChip T="string" Size="Size.Small" Color="Color.Info" Text="@L["DomainList:Counts:RelatedDependencies", GetRelatedServiceCount(domain.Name)]" />
                                         }
-                                    </MudStack>
-                                </MudStack>
+                                    </div>
+                                </div>
 
                                 @if (!string.IsNullOrEmpty(domain.Description))
                                 {
@@ -97,7 +97,7 @@
             }
         </MudGrid>
     }
-</MudStack>
+</div>
 
 @code {
     [Parameter] public EventCallback<DomainInfo> OnDomainSelected { get; set; }

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainList.razor.css
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/DomainList.razor.css
@@ -1,3 +1,11 @@
+.domain-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 0;
+    width: 100%;
+}
+
 .domain-list ::deep .domain-list__header,
 .domain-list ::deep .domain-list__state {
     background: var(--mud-palette-surface);
@@ -6,32 +14,84 @@
     padding: 1rem;
 }
 
-.domain-card {
+.domain-list__header-row {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    min-width: 0;
+}
+
+.domain-list ::deep .mud-grid {
+    align-items: stretch;
+    min-width: 0;
+}
+
+.domain-list ::deep .mud-grid-item {
+    display: flex;
+    min-width: 0;
+}
+
+.domain-list ::deep .domain-card {
     --domain-card-color: var(--mud-palette-text-secondary);
     background: var(--mud-palette-surface);
     border: 1px solid var(--mud-palette-divider);
     border-radius: 8px;
+    flex: 1 1 auto;
     height: 100%;
+    min-width: 0;
     transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+    width: 100%;
 }
 
-.domain-card:hover,
-.domain-card:focus-visible {
+.domain-list ::deep .domain-card .mud-card-content {
+    min-width: 0;
+    width: 100%;
+}
+
+.domain-list ::deep .domain-card:hover,
+.domain-list ::deep .domain-card:focus-visible {
     border-color: color-mix(in srgb, var(--domain-card-color) 42%, var(--mud-palette-divider));
     box-shadow: 0 12px 28px color-mix(in srgb, var(--mud-palette-text-primary) 7%, transparent) !important;
     transform: translateY(-1px);
 }
 
-.domain-card:focus-visible {
+.domain-list ::deep .domain-card:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--domain-card-color) 72%, transparent);
     outline-offset: 2px;
+}
+
+.domain-card__header {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: space-between;
+    min-width: 0;
 }
 
 .domain-card__identity {
     align-items: center;
     display: flex;
+    flex: 1 1 10rem;
     gap: 0.625rem;
     min-width: 0;
+}
+
+.domain-card__counts {
+    align-items: flex-end;
+    display: flex;
+    flex: 0 1 auto;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-inline-start: auto;
+    max-width: 100%;
+    min-width: 0;
+}
+
+.domain-card__counts ::deep .mud-chip {
+    margin: 0;
+    max-width: 100%;
 }
 
 .domain-card__icon {
@@ -46,44 +106,69 @@
     justify-content: center;
 }
 
-.domain-card ::deep .domain-card__title {
+.domain-list ::deep .domain-card__title {
     color: var(--mud-palette-text-primary);
     font-weight: 750;
     min-width: 0;
     overflow-wrap: anywhere;
 }
 
-.domain-card ::deep .domain-card__description {
+.domain-list ::deep .domain-card__description {
     color: var(--mud-palette-text-primary);
+    overflow-wrap: anywhere;
 }
 
-.domain-card ::deep .domain-card__meta {
+.domain-list ::deep .domain-card__meta {
     color: var(--mud-palette-text-secondary);
+    overflow-wrap: anywhere;
 }
 
-.domain-card ::deep .domain-card__meta--strong {
+.domain-list ::deep .domain-card__meta--strong {
     color: var(--mud-palette-text-primary);
 }
 
-.domain-card--primary { --domain-card-color: var(--mud-palette-primary); }
-.domain-card--secondary { --domain-card-color: var(--mud-palette-secondary); }
-.domain-card--tertiary { --domain-card-color: var(--mud-palette-tertiary); }
-.domain-card--info { --domain-card-color: var(--mud-palette-info); }
-.domain-card--success { --domain-card-color: var(--mud-palette-success); }
-.domain-card--warning { --domain-card-color: var(--mud-palette-warning); }
-.domain-card--default { --domain-card-color: var(--mud-palette-text-secondary); }
+.domain-list ::deep .domain-card--primary { --domain-card-color: var(--mud-palette-primary); }
+.domain-list ::deep .domain-card--secondary { --domain-card-color: var(--mud-palette-secondary); }
+.domain-list ::deep .domain-card--tertiary { --domain-card-color: var(--mud-palette-tertiary); }
+.domain-list ::deep .domain-card--info { --domain-card-color: var(--mud-palette-info); }
+.domain-list ::deep .domain-card--success { --domain-card-color: var(--mud-palette-success); }
+.domain-list ::deep .domain-card--warning { --domain-card-color: var(--mud-palette-warning); }
+.domain-list ::deep .domain-card--default { --domain-card-color: var(--mud-palette-text-secondary); }
 
-.cursor-pointer {
+.domain-list ::deep .cursor-pointer {
     cursor: pointer;
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .domain-card {
-        transition: none;
+@media (max-width: 599.98px) {
+    .domain-list__header-row {
+        align-items: stretch;
+        flex-direction: column;
     }
 
-    .domain-card:hover,
-    .domain-card:focus-visible {
+    .domain-list__header-row ::deep .mud-button-root {
+        width: 100%;
+    }
+
+    .domain-card__header {
+        flex-direction: column;
+    }
+
+    .domain-card__counts {
+        align-items: flex-start;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        margin-inline-start: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .domain-list ::deep .domain-card {
+        transition: none !important;
+    }
+
+    .domain-list ::deep .domain-card:hover,
+    .domain-list ::deep .domain-card:focus-visible {
         transform: none;
     }
 }

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceDiscoveryServiceDetail.razor
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceDiscoveryServiceDetail.razor
@@ -23,16 +23,36 @@
                     <MudPaper Class="pa-4" Elevation="0">
                         <MudGrid>
                             <MudItem xs="12" sm="6">
-                                <MudTextField T="string" Label="@L["ServiceDetail:Overview:Fields:AppId"]" Value="@Service.AppId" ReadOnly="true" />
+                                <MudTextField T="string"
+                                              Label="@L["ServiceDetail:Overview:Fields:AppId"]"
+                                              Value="@Service.AppId"
+                                              ReadOnly="true"
+                                              Sizing="InputSizing.Auto"
+                                              MaxLines="3" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudTextField T="string" Label="@L["ServiceDetail:Overview:Fields:ServiceName"]" Value="@Service.AppName" ReadOnly="true" />
+                                <MudTextField T="string"
+                                              Label="@L["ServiceDetail:Overview:Fields:ServiceName"]"
+                                              Value="@Service.AppName"
+                                              ReadOnly="true"
+                                              Sizing="InputSizing.Auto"
+                                              MaxLines="3" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudTextField T="string" Label="@L["ServiceDetail:Overview:Fields:ProjectName"]" Value="@Service.ProjectName" ReadOnly="true" />
+                                <MudTextField T="string"
+                                              Label="@L["ServiceDetail:Overview:Fields:ProjectName"]"
+                                              Value="@Service.ProjectName"
+                                              ReadOnly="true"
+                                              Sizing="InputSizing.Auto"
+                                              MaxLines="3" />
                             </MudItem>
                             <MudItem xs="12" sm="6">
-                                <MudTextField T="string" Label="@L["ServiceDetail:Overview:Fields:DomainName"]" Value="@Service.DomainName" ReadOnly="true" />
+                                <MudTextField T="string"
+                                              Label="@L["ServiceDetail:Overview:Fields:DomainName"]"
+                                              Value="@Service.DomainName"
+                                              ReadOnly="true"
+                                              Sizing="InputSizing.Auto"
+                                              MaxLines="3" />
                             </MudItem>
                         </MudGrid>
                     </MudPaper>

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceDiscoveryServiceList.razor.css
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceDiscoveryServiceList.razor.css
@@ -1,12 +1,23 @@
 .service-list {
+    max-width: 100%;
     min-width: 0;
+    width: 100%;
 }
 
 .service-list ::deep .service-list__grid {
     border: 1px solid var(--mud-palette-divider);
     border-radius: 8px;
     box-shadow: none;
-    overflow: hidden;
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
+.service-list ::deep .service-list__grid .mud-table-container {
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    width: 100%;
 }
 
 .service-list ::deep .service-list__grid .mud-table-head {
@@ -15,6 +26,16 @@
 
 .service-list ::deep .service-list__grid .mud-table-row {
     transition: background-color 150ms ease;
+}
+
+.service-list ::deep .mo-context-menu-root {
+    display: block !important;
+    height: 1px;
+    inset: 0 auto auto 0;
+    overflow: hidden;
+    pointer-events: none;
+    position: fixed;
+    width: 1px;
 }
 
 .service-list ::deep .service-list__instance-status {

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceFilterPanel.razor
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceFilterPanel.razor
@@ -4,92 +4,102 @@
 @using Monica.ServiceDiscovery.UIServiceDiscovery.Support
 @inject IStringLocalizer<ServiceDiscoveryResource> L
 
-<MudPaper Class="service-filter-panel" Elevation="0" Outlined="true">
-    <MudGrid>
-        <MudItem xs="12" sm="6" md="4">
-            <MudTextField @bind-Value="FilterText"
-                          Label="@L["ServiceFilter:Labels:Search"]"
-                          HelperText="@L["ServiceFilter:Labels:SearchHelp"]"
-                          Variant="Variant.Outlined"
-                          Adornment="Adornment.Start"
-                          AdornmentIcon="@Icons.Material.Filled.Search"
-                          Immediate="true"
-                          DebounceInterval="300"
-                          OnDebounceIntervalElapsed="OnFilterTextChanged" />
-        </MudItem>
-        <MudItem xs="12" md="4">
-            <MudText Typo="Typo.subtitle2" Class="mb-2">@L["ServiceFilter:Labels:StatusFilter"]</MudText>
-            <div class="d-flex flex-wrap gap-1 mb-2">
-                <MudButton Size="Size.Small"
-                           Variant="Variant.Text"
-                           Color="Color.Primary"
-                           OnClick="SelectAllStatuses">
-                    @L["Shared:Actions:SelectAll"]
-                </MudButton>
-                <MudButton Size="Size.Small"
-                           Variant="Variant.Text"
-                           Color="Color.Secondary"
-                           OnClick="ClearAllStatuses">
-                    @L["Shared:Actions:Clear"]
-                </MudButton>
+<div class="service-filter-panel">
+    <MudPaper Class="service-filter-panel__surface" Elevation="0" Outlined="true">
+        <div class="service-filter-panel__main">
+            <div class="service-filter-panel__search">
+                <MudTextField @bind-Value="FilterText"
+                              Label="@L["ServiceFilter:Labels:Search"]"
+                              HelperText="@L["ServiceFilter:Labels:SearchHelp"]"
+                              Variant="Variant.Outlined"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Immediate="true"
+                              DebounceInterval="300"
+                              OnDebounceIntervalElapsed="OnFilterTextChanged" />
             </div>
-            <MudChipSet T="ServiceStatus"
-                        SelectionMode="SelectionMode.MultiSelection"
-                        SelectedValues="SelectedStatuses"
-                        SelectedValuesChanged="OnSelectedStatusesChanged">
-                @foreach (var status in AllStatuses)
-                {
-                    var isSelected = SelectedStatuses.Contains(status);
-                    <MudChip T="ServiceStatus"
-                             Value="status"
-                             Color="@status.GetColor()"
-                             Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
-                             Size="Size.Small">
-                        @GetStatusLabel(status)
-                    </MudChip>
-                }
-            </MudChipSet>
-        </MudItem>
-        <MudItem xs="12" md="4">
-            <MudText Typo="Typo.subtitle2" Class="mb-2">@L["ServiceFilter:Labels:DomainFilter"]</MudText>
-            <div class="d-flex flex-wrap gap-1 mb-2">
-                <MudButton Size="Size.Small"
-                           Variant="Variant.Text"
-                           Color="Color.Primary"
-                           OnClick="SelectAllDomains">
-                    @L["Shared:Actions:SelectAll"]
-                </MudButton>
-                <MudButton Size="Size.Small"
-                           Variant="Variant.Text"
-                           Color="Color.Secondary"
-                           OnClick="ClearAllDomains">
-                    @L["Shared:Actions:Clear"]
-                </MudButton>
+            <div class="service-filter-panel__filter">
+                <div class="service-filter-panel__filter-heading">
+                    <MudText Typo="Typo.subtitle2">@L["ServiceFilter:Labels:StatusFilter"]</MudText>
+                    <div class="service-filter-panel__filter-actions">
+                        <MudButton Size="Size.Small"
+                                   Variant="Variant.Text"
+                                   Color="Color.Primary"
+                                   OnClick="SelectAllStatuses">
+                            @L["Shared:Actions:SelectAll"]
+                        </MudButton>
+                        <MudButton Size="Size.Small"
+                                   Variant="Variant.Text"
+                                   Color="Color.Secondary"
+                                   OnClick="ClearAllStatuses">
+                            @L["Shared:Actions:Clear"]
+                        </MudButton>
+                    </div>
+                </div>
+                <div class="service-filter-panel__chips">
+                    <MudChipSet T="ServiceStatus"
+                                SelectionMode="SelectionMode.MultiSelection"
+                                SelectedValues="SelectedStatuses"
+                                SelectedValuesChanged="OnSelectedStatusesChanged">
+                        @foreach (var status in AllStatuses)
+                        {
+                            var isSelected = SelectedStatuses.Contains(status);
+                            <MudChip T="ServiceStatus"
+                                     Value="status"
+                                     Color="@status.GetColor()"
+                                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                                     Size="Size.Small">
+                                @GetStatusLabel(status)
+                            </MudChip>
+                        }
+                    </MudChipSet>
+                </div>
             </div>
-            <MudChipSet T="string"
-                        SelectionMode="SelectionMode.MultiSelection"
-                        SelectedValues="SelectedDomains"
-                        SelectedValuesChanged="OnSelectedDomainsChanged">
-                @foreach (var domain in AllDomains)
-                {
-                    var isSelected = SelectedDomains.Contains(domain);
-                    <MudChip T="string"
-                             Value="domain"
-                             Color="@(isSelected ? Color.Info : Color.Default)"
-                             Size="Size.Small">
-                        @domain
-                    </MudChip>
-                }
-            </MudChipSet>
-        </MudItem>
-        <MudItem xs="12" sm="6">
+            <div class="service-filter-panel__filter">
+                <div class="service-filter-panel__filter-heading">
+                    <MudText Typo="Typo.subtitle2">@L["ServiceFilter:Labels:DomainFilter"]</MudText>
+                    <div class="service-filter-panel__filter-actions">
+                        <MudButton Size="Size.Small"
+                                   Variant="Variant.Text"
+                                   Color="Color.Primary"
+                                   OnClick="SelectAllDomains">
+                            @L["Shared:Actions:SelectAll"]
+                        </MudButton>
+                        <MudButton Size="Size.Small"
+                                   Variant="Variant.Text"
+                                   Color="Color.Secondary"
+                                   OnClick="ClearAllDomains">
+                            @L["Shared:Actions:Clear"]
+                        </MudButton>
+                    </div>
+                </div>
+                <div class="service-filter-panel__chips">
+                    <MudChipSet T="string"
+                                SelectionMode="SelectionMode.MultiSelection"
+                                SelectedValues="SelectedDomains"
+                                SelectedValuesChanged="OnSelectedDomainsChanged">
+                        @foreach (var domain in AllDomains)
+                        {
+                            var isSelected = SelectedDomains.Contains(domain);
+                            <MudChip T="string"
+                                     Value="domain"
+                                     Color="@(isSelected ? Color.Info : Color.Default)"
+                                     Size="Size.Small">
+                                @domain
+                            </MudChip>
+                        }
+                    </MudChipSet>
+                </div>
+            </div>
+        </div>
+        <div class="service-filter-panel__footer">
             <MudSwitch T="bool" Value="ShowOnlyWithInstances"
                        ValueChanged="OnShowOnlyWithInstancesChanged"
                        Label="@L["ServiceFilter:Labels:ShowOnlyWithInstances"]"
                        Color="Color.Primary" />
-        </MudItem>
-    </MudGrid>
-</MudPaper>
+        </div>
+    </MudPaper>
+</div>
 
 
 @code {

--- a/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceFilterPanel.razor.css
+++ b/Monica.ServiceDiscovery/UIServiceDiscovery/Components/ServiceFilterPanel.razor.css
@@ -1,12 +1,114 @@
 .service-filter-panel {
+    min-width: 0;
+    width: 100%;
+}
+
+.service-filter-panel ::deep .service-filter-panel__surface {
     background: color-mix(in srgb, var(--mud-palette-primary) 2%, var(--mud-palette-surface));
     border-color: var(--mud-palette-divider);
     border-radius: 8px;
+    overflow: hidden;
+    width: 100%;
+}
+
+.service-filter-panel__main {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: minmax(16rem, 0.9fr) repeat(2, minmax(0, 1fr));
     padding: 1rem;
 }
 
+.service-filter-panel__search,
+.service-filter-panel__filter,
+.service-filter-panel__chips {
+    min-width: 0;
+}
+
+.service-filter-panel__filter {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+}
+
+.service-filter-panel__filter-heading,
+.service-filter-panel__filter-actions,
+.service-filter-panel__footer {
+    align-items: center;
+    display: flex;
+}
+
+.service-filter-panel__filter-heading {
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    justify-content: space-between;
+    min-width: 0;
+}
+
+.service-filter-panel__filter-actions {
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    gap: 0.125rem;
+    justify-content: flex-end;
+}
+
+.service-filter-panel__filter-actions ::deep .mud-button-root {
+    min-width: 0;
+}
+
+.service-filter-panel__chips ::deep .mud-chipset,
+.service-filter-panel__chips ::deep .mud-chipset-items {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.service-filter-panel__chips ::deep .mud-chipset-items {
+    flex-wrap: wrap;
+    gap: 0.375rem;
+}
+
+.service-filter-panel__chips ::deep .mud-chip {
+    margin: 0;
+    max-width: 100%;
+}
+
+.service-filter-panel__footer {
+    background: var(--mud-palette-surface);
+    border-top: 1px solid var(--mud-palette-divider);
+    min-width: 0;
+    padding: 0.625rem 1rem;
+}
+
+.service-filter-panel__footer ::deep .mud-switch {
+    max-width: 100%;
+    min-width: 0;
+}
+
+@media (max-width: 1199.98px) {
+    .service-filter-panel__main {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .service-filter-panel__search {
+        grid-column: 1 / -1;
+    }
+}
+
 @media (max-width: 599.98px) {
-    .service-filter-panel {
+    .service-filter-panel__main {
+        gap: 1rem;
+        grid-template-columns: minmax(0, 1fr);
         padding: 0.875rem;
+    }
+
+    .service-filter-panel__search {
+        grid-column: auto;
+    }
+
+    .service-filter-panel__filter-actions {
+        justify-content: flex-start;
+    }
+
+    .service-filter-panel__footer {
+        padding-inline: 0.875rem;
     }
 }


### PR DESCRIPTION
## Summary

Improve the visual hierarchy, control alignment, responsive containment, and local scrolling of the Configuration, Service Discovery, and Repository diagnostic pages while preserving Monica's existing design language.  

This is a focused, non-breaking UI fix. It does not change public APIs, business logic, component contracts, localization keys, or lifecycle behavior.  

## Changes  

### Configuration  

- Align the Import, Export, and Refresh actions to a consistent 40px height.
- Place all history filters and the Search action on one desktop track, with responsive single-column containment on narrow screens.  
- Keep history table horizontal scrolling inside the table container.

### Service Discovery

- Reorganize service filters into a three-column desktop, two-column tablet, and single-column mobile layout.  
- Clarify the hierarchy of search, status filters, domain filters, bulk actions, chips, and the instance-only switch.   
- Improve domain card sizing, long-text wrapping, keyboard focus, and responsive detail layouts.  
- Allow long service identifiers to wrap in the detail dialog.  
- Keep table and tab overflow local to their owning containers.  
- Stabilize the service context-menu anchor without changing the shared menu component.  

### Repository Diagnostics

- Normalize Refresh, Update Current, and Update All actions to 40px.
- Preserve whole-button wrapping on narrow screens.
- Let the context rail fill the remaining height and scroll locally.

### Code Cleanup

- Simplify the changed Razor structure and scoped CSS selectors while preserving rendered output, component interfaces, localization keys, and interaction behavior.
- Keep the local context-menu anchor and reduced-motion overrides because browser verification confirmed they are required.

## Behavior Preserved

- Import/export parameters and results
- Dialog open, close, confirm, and cancel behavior
- Form validation and loading states
- Existing component parameters and callbacks
- Page state and component lifecycle behavior
- Existing zh-CN and en-US resources

No user-visible text or localization resource was changed.

## Validation

- [x] Browser regression at 1440×900, 929×900, and 390×844
- [x] Light and dark themes
- [x] Import dialog open and cancel
- [x] Service context menu opening and outside-click closing
- [x] Service detail close button and Escape handling
- [x] Domain selection, detail view, and back navigation
- [x] Repository migration confirm, cancel, and resulting state
- [x] No document-level horizontal overflow in target viewports
- [x] Browser console: 0 warnings, 0 errors
- [x] UI theme token validation
- [x] MudBlazor CSS variable validation: 712 files, 0 unknown variables
- [x] Strict localization validation: 20 projects, 34 resources, 0 issues
- [x] `git diff --check`
- [x] `dotnet build Monica.slnx -m`: 0 warnings, 0 errors

No new automated unit tests were added because the changes are limited to Razor layout and scoped styling. Existing interactions were covered through browser regression.

## Breaking Changes

None.

## Related Issue or Discussion

N/A — focused, non-breaking visual regression fix.

## Screenshots

Attach sanitized before/after screenshots for:

<img width="2788" height="1604" alt="1384a443-cb69-4e21-a9ae-c166592ebda2" src="https://github.com/user-attachments/assets/8a240a4f-9fae-4808-a7c2-44098aaa1e22" />

<img width="2788" height="1604" alt="20cf4fe6-5f1e-4e74-86f3-0959ddfde702" src="https://github.com/user-attachments/assets/d4a0fee0-940f-47f1-ad82-4b712eb699a7" />

<img width="2788" height="1604" alt="image" src="https://github.com/user-attachments/assets/821139fa-90c3-4fc7-93a9-55d647a8c583" />

<img width="2788" height="1604" alt="4f4af21a-f65a-45c3-a0d1-7e3025487ead" src="https://github.com/user-attachments/assets/6d9d957e-979a-4141-b805-8fec655fe033" />

<img width="2788" height="1604" alt="54ac5228-7c22-4f6d-8be4-0bde2ae81384" src="https://github.com/user-attachments/assets/90ea35cf-b579-416d-b21f-c2d61b48968f" />
